### PR TITLE
[티켓추가예정] 회원가입 폼 help text 추가

### DIFF
--- a/client/src/components/SignupPage/SignupMenu/index.tsx
+++ b/client/src/components/SignupPage/SignupMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './style';
 import { Link, useNavigate } from 'react-router-dom';
 import { DEFAULT_PROFILE_IMG_URL, HOST } from '../../../constants';
@@ -46,10 +46,15 @@ const SignupMenu = () => {
   const signupFormSubmit = async (d: any) => {
     const response = await httpPostSignup(d);
     if (response.ok) {
-      alert('good');
       navigate('/');
+    } else {
+      setErr('이미 존재하는 아이디인 것 같아요');
     }
   };
+
+  useEffect(() => {
+    setErr(Object.keys(errors).length !== 0 ? '회원가입 양식이 틀렸어요' : '');
+  }, [errors]);
 
   return (
     <S.Container>


### PR DESCRIPTION
## 요약
특정한 상황에서 회원가입 폼에 help text가 표시되도록 수정했습니다.
## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/202445698-d28af699-eb7f-4939-8b89-acbe55cc1131.png)

## 작업 내용
1. 올바르지 않은 양식을 제출하려는 경우 help text가 표시되도록 수정했습니다.
2. 아이디 또는 이메일 중복으로 인해 회원가입에 실패할 경우 help text가 표시되도록 수정했습니다.
## 비고
1. 아이디: 필수
2. 비밀번호: 필수, 8자리 이상 15자리 이하
3. 닉네임: 선택 → 논의 필요
