### PR TITLE
[BE] 태그 생성 및 조회 API

### DIFF
--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import authRouter from './auth';
 import taskRouter from './task';
+import tagRouter from './tag';
 
 const router = express.Router();
 
 router.use('/auth', authRouter);
 router.use('/task', taskRouter);
+router.use('/tag', tagRouter);
 
 export default router;

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -11,4 +11,11 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   res.json(tags);
 });
 
+router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const { title, color } = req.body;
+  await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx]);
+  res.sendStatus(200);
+});
+
 export default router;

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const tags = await executeSql('select * from tag where user_idx = ?', [userIdx.toString()]);
+  res.json(tags);
+});
+
+export default router;

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const tags = await executeSql('select * from tag where user_idx = ?', [userIdx.toString()]);
+  const tags = await executeSql('select idx, title, color from tag where user_idx = ?', [userIdx.toString()]);
   res.json(tags);
 });
 


### PR DESCRIPTION
## 요약
태그를 DB에서 불러오는 API와 DB에 추가하는 API를 작성했습니다.
## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/202965887-869e3877-f651-4818-a4b9-caf57ef4e033.png)

## 작업 내용
1. 태그 생성 API 작성
2. 태그 조회 API 작성

## 비고
1. 로그인을 완료하세요.
3. 개발자 도구를 열고 다음 코드를 입력하세요.
```
fetch('http://localhost:8000/api/v1/tag', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({title: '태그', color: 'ffffff'}),
});
```

4. 주소창에 `http://localhost:8000/api/v1/tag`를 입력하세요.