### PR TITLE
[BE] task 생성 API 보완

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -13,9 +13,29 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const { title, importance, startedAt, endedAt, location, isPublic, tagIdx, labels } = req.body;
-  const result = await executeSql('insert into task (title, importance, public, user_idx) values (?, ?, ?, ?)', [title, importance, isPublic, userIdx]);
-  res.send(200);
+  const { title, importance, startedAt, endedAt, lat, lng, isPublic, tagIdx, content, done, date, labels } = req.body;
+  const result = await executeSql('insert into task (title, importance, date, started_at, ended_at, lat, lng, content, done, public, tag_idx, user_idx) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+    title,
+    importance,
+    date,
+    startedAt,
+    endedAt,
+    lat,
+    lng,
+    content,
+    done,
+    isPublic,
+    tagIdx,
+    userIdx,
+  ]);
+
+  const taskIdx = result.insertId;
+  await Promise.all(
+    labels.map(({ labelIdx, amount }) => {
+      executeSql('insert into task_label (task_idx, label_idx, amount) value (?, ?, ?)', [taskIdx, labelIdx, amount]);
+    })
+  );
+  res.sendStatus(200);
 });
 
 export default router;

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -11,31 +11,51 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   res.json(rows);
 });
 
+const MAX_IMPORTANCE = 5;
+const validateImportance = (importance: number) => {
+  return importance <= MAX_IMPORTANCE;
+};
+const validateLatitude = (lat: number) => {
+  return lat >= -90 && lat <= 90;
+};
+const validateLongitude = (lng: number) => {
+  return lng >= -180 && lng <= 180;
+};
+
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, importance, startedAt, endedAt, lat, lng, isPublic, tagIdx, content, done, date, labels } = req.body;
-  const result = await executeSql('insert into task (title, importance, date, started_at, ended_at, lat, lng, content, done, public, tag_idx, user_idx) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
-    title,
-    importance,
-    date,
-    startedAt,
-    endedAt,
-    lat,
-    lng,
-    content,
-    done,
-    isPublic,
-    tagIdx,
-    userIdx,
-  ]);
 
-  const taskIdx = result.insertId;
-  await Promise.all(
-    labels.map(({ labelIdx, amount }) => {
-      executeSql('insert into task_label (task_idx, label_idx, amount) value (?, ?, ?)', [taskIdx, labelIdx, amount]);
-    })
-  );
-  res.sendStatus(200);
+  if (!validateImportance(importance)) res.sendStatus(400);
+  if (!validateLatitude(lat)) res.sendStatus(400);
+  if (!validateLongitude(lng)) res.sendStatus(400);
+
+  try {
+    const result = await executeSql('insert into task (title, importance, date, started_at, ended_at, lat, lng, content, done, public, tag_idx, user_idx) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+      title,
+      importance,
+      date,
+      startedAt,
+      endedAt,
+      lat,
+      lng,
+      content,
+      done,
+      isPublic,
+      tagIdx,
+      userIdx,
+    ]);
+
+    const taskIdx = result.insertId;
+    await Promise.all(
+      labels.map(({ labelIdx, amount }) => {
+        executeSql('insert into task_label (task_idx, label_idx, amount) value (?, ?, ?)', [taskIdx, labelIdx, amount]);
+      })
+    );
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(400);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## 요약
API 문서에 명시된 대로 body에 필요한 필드를 추가했습니다.
## 작업 내용
1. `task` 테이블에 추가적으로 `날짜`, `시작 시각`, `종료 시각`, `좌표`, `완료 여부`, `태그`, `내용` 컬럼이 입력되도록 수정했습니다.
2. `task_label` 테이블에 행을 삽입하는 과정이 추가되었습니다.
3. 
## 테스트 방법
1. 로그인을 완료하세요.
2. 개발자 도구를 열고 다음 코드를 입력하세요.
```
fetch('http://localhost:8000/api/v1/task', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({
    title: '낮잠',
    importance: 5,
    startedAt: '11:00',
    endedAt: '22:00',
    lat: 37.3584879,
    lng: 127.105037,
    isPublic: true,
    tagIdx: 1,
    content: 'zzZ..',
    done: false,
    date: '2022-11-22',
    labels: [
      {
        labelIdx: 1,
        amount: 11
      }
    ]
  }),
});
```
3. 주소창에 `http://localhost:8000/api/v1/task`를 입력하세요.
