### PR TITLE
[BE]  태그 생성 API - 반환 값에 idx 추가

### DIFF
--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -14,9 +14,8 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color } = req.body;
-  await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx]);
-  const newIdx = await executeSql('select last_insert_id()');
-  res.status(200).send({ idx: newIdx[0]['last_insert_id()'] });
+  const result = await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx]);
+  res.status(200).send({ idx: result.insertId });
 });
 
 export default router;

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -15,7 +15,8 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color } = req.body;
   await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx]);
-  res.sendStatus(200);
+  const newIdx = await executeSql('select last_insert_id()');
+  res.status(200).send({ idx: newIdx[0]['last_insert_id()'] });
 });
 
 export default router;


### PR DESCRIPTION
## 요약
- 태그 생성 시 생성된 요소에 대한 idx 값 반환
- **task 생성 모달에서 task 생성을 위해 tag_idx를 post 해야하기 때문**에 필요하다고 판단됨

## 작동 화면
<img width="605" alt="image" src="https://user-images.githubusercontent.com/73420533/203083247-1db032f4-7fa3-47c4-b4bf-0d94de41ec7d.png">

## 작업 내용
- `/api/v1/tag` response 에 생성된 tag에 대한 idx 추가
- 테스트 방법
```
fetch('http://localhost:8000/api/v1/tag', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({title: '태그', color: 'ffffff'}),
});
```

## 비고
