### PR TITLE
[FE] [7-16] 태스크 생성 모달 내 태그 조회 / 생성 / 선택 Input 창

### DIFF
--- a/client/src/components/MainPage/MainContents/Log/TaskItem.tsx
+++ b/client/src/components/MainPage/MainContents/Log/TaskItem.tsx
@@ -11,7 +11,7 @@ const TaskList = ({ taskList, activeTask }: taskListProps) => {
     <>
       {taskList.map(({ tag_name, idx, title, startedAt, endedAt, importance, location, content, done, isPublic }) => {
         return (
-          <S.TaskItems key={'task' + idx} data-idx={idx} data-tag={tag_name} data-active={idx === activeTask}  done={done}>
+          <S.TaskItem key={'task' + idx} data-idx={idx} data-tag={tag_name} data-active={idx === activeTask} done={done}>
             <S.TaskMainInfos>
               <S.TaskTime>{startedAt}</S.TaskTime>
               <S.TaskTitle>{title}</S.TaskTitle>

--- a/client/src/components/MainPage/TaskModal/TagInput.tsx
+++ b/client/src/components/MainPage/TaskModal/TagInput.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect, useRef } from 'react';
+import axios from 'axios';
+import { HOST } from '../../../constants';
+import styled from 'styled-components';
+import useInput from '../../../hooks/useInput';
+import { RiCloseLine } from 'react-icons/ri';
+import { Tag } from 'GlobalType';
+
+axios.defaults.withCredentials = true; // withCredentials 전역 설정
+
+interface Props {
+  setTagIdx: React.Dispatch<React.SetStateAction<number | undefined>>;
+}
+
+const TagInput = (props: Props) => {
+  const [tagList, setTagList] = useState<Tag[]>([]);
+  const [tagInput, onTagInputChange, setTagInput] = useInput('');
+  const [isTagFocus, setIsTagFocus] = useState<Boolean>(false); // Input창이 Focus될 때만 List 표시
+  const [selectedTag, setSelectedTag] = useState<Tag>(); // 선택된 하나의 태그
+  const [randomColor, setRandomColor] = useState(''); // 새로운 Tag 추가 시 색깔 랜덤 배정
+
+  //TAG GET
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const result = await axios.get(`${HOST}/api/v1/tag`);
+        setTagList(result.data);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    fetchData();
+  }, [, () => postNewTag]);
+
+  //검색된 Tag
+  const filteredTagList = tagList.filter((itemList) => itemList.title.toUpperCase().includes(tagInput.toUpperCase()));
+
+  //하나의 태그 선택
+  const setTagItem = (e: React.MouseEvent<HTMLDivElement>) => {
+    setSelectedTag(filteredTagList.find((item) => item.idx.toString() === e.currentTarget!.dataset.idx));
+    props.setTagIdx(Number(e.currentTarget.dataset.idx));
+  };
+
+  //태그 선택 해제
+  const unSetTagItem = () => {
+    setSelectedTag(undefined);
+    props.setTagIdx(undefined);
+    setIsTagFocus(true);
+    setTagInput('');
+  };
+
+  //POST TAG
+  const postNewTag = async () => {
+    try {
+      const newTagData = {
+        title: tagInput,
+        color: randomColor,
+      } as Tag;
+      const result = await axios.post(`${HOST}/api/v1/tag`, newTagData);
+
+      if (result.status === 200) {
+        setSelectedTag(newTagData); // 표시되는 데이터 갱신
+        props.setTagIdx(result.data.idx); // tagIdx(form에서 사용되는 값)를 추가된 Tag의 idx로 갱신
+      }
+    } catch (error) {
+      alert('Tag 생성에 실패했습니다.');
+      // 각 실패 처리에 대한 논의 후 에러 메시지 분기 추가하겠습니다.
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    setRandomColor(`${Math.round(Math.random() * 0xffff).toString(16)}`);
+  }, []);
+
+  // 하나의 태그가 선택되었을 때
+  if (selectedTag !== undefined)
+    return (
+      <TagContainer>
+        <Bar>
+          <SelectedTag color={'#' + selectedTag.color}>
+            {selectedTag.title} <CloseButton onClick={unSetTagItem} />
+          </SelectedTag>
+        </Bar>
+      </TagContainer>
+    );
+
+  // 태그 선택 전
+  return (
+    <TagContainer>
+      <InputBar onChange={onTagInputChange} onFocus={(e) => setIsTagFocus(true)} onBlur={(e) => setIsTagFocus(false)}></InputBar>
+      {isTagFocus ? (
+        <TagList>
+          {filteredTagList.map((item) => {
+            return (
+              <TagListItem key={item.idx} data-idx={item.idx} onMouseDown={setTagItem}>
+                <TagTitle color={'#' + item.color}>
+                  <a>{item.title}</a>
+                </TagTitle>
+              </TagListItem>
+            );
+          })}
+          {tagInput != '' ? (
+            <TagListItem onMouseDown={postNewTag}>
+              <TagTitle color={'#' + randomColor}>
+                생성 : <a>{tagInput}</a>
+              </TagTitle>
+            </TagListItem>
+          ) : null}
+        </TagList>
+      ) : null}
+    </TagContainer>
+  );
+};
+
+export default TagInput;
+
+const TagContainer = styled.div`
+  margin: auto;
+  z-index: 500;
+`;
+
+const TagList = styled.div`
+  margin-top: 0rem;
+  background: white;
+  border: 1px solid var(--color-gray3);
+  transform: translateY(3px);
+  border-radius: 8px;
+  color: black;
+  width: 23.6rem;
+  height: 8rem;
+  overflow: scroll;
+  font-size: 0.8rem;
+`;
+
+const TagListItem = styled.div`
+  :hover {
+    background-color: var(--color-gray1);
+  }
+`;
+
+const TagTitle = styled.div`
+  display: table-cell;
+  vertical-align: middle;
+  padding: 2.5px 3px 2.5px 5px;
+  a {
+    display: inline-block;
+    padding: 2px 6px 2px 6px;
+    background-color: ${(props) => props.color || 'black'};
+    border-radius: 3px;
+    height: 19px;
+    line-height: 19px;
+  }
+  font-size: 0.8rem;
+`;
+
+export const InputBar = styled.input`
+  margin: auto;
+  background: var(--color-gray0);
+  border: 1px solid var(--color-gray3);
+  border-radius: 8px;
+  color: black;
+  width: 22.6rem;
+  height: 2.18rem;
+  font-size: 0.8rem;
+  padding-left: 1rem;
+`;
+
+export const Bar = styled.div`
+  margin: auto;
+  background: var(--color-gray0);
+  border: 1px solid var(--color-gray3);
+  color: black;
+  width: 23rem;
+  height: 2.18rem;
+  border-radius: 8px;
+  padding-left: 0.6rem;
+  display: flex;
+  align-items: center;
+`;
+
+const SelectedTag = styled.div`
+  padding: 2px 4px 2px 8px;
+  display: flex;
+  line-height: 19px;
+  height: 19px;
+  background-color: ${(props) => props.color || 'black'};
+  border-radius: 3px;
+  font-size: 0.8rem;
+`;
+
+const CloseButton = styled(RiCloseLine)`
+  width: 12px;
+  height: 12px;
+  margin: auto;
+  padding: 3px;
+  cursor: pointer;
+`;

--- a/client/src/components/MainPage/TaskModal/index.tsx
+++ b/client/src/components/MainPage/TaskModal/index.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './style';
 import ImportanceInput from './ImportanceInput';
+import TagInput from './TagInput';
+import useInput from '../../../hooks/useInput';
 interface Props {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const TaskModal = (props: Props) => {
+  const [tagidx, setTagIdx] = useState<number | undefined>();
+
+  useEffect(() => console.log(tagidx), [tagidx]); // 선택된 tag idx로 변경되는지 test 확인 용 코드
+
   return (
     <S.Container>
-      <S.CalendarContainer>
+      <S.ModalContainer>
         {' '}
         <S.CloseButton onClick={(e) => props.setIsModalOpen(false)} />
         <S.Date>{'• 11.12 •'}</S.Date>
@@ -23,7 +29,7 @@ const TaskModal = (props: Props) => {
               <tr>
                 <td>태그</td>
                 <td>
-                  <S.InputBar />
+                  <TagInput setTagIdx={setTagIdx}></TagInput>
                 </td>
               </tr>
               <tr>
@@ -52,7 +58,7 @@ const TaskModal = (props: Props) => {
         <S.Border>
           <h4>{'더보기  ▼'}</h4>
         </S.Border>
-      </S.CalendarContainer>
+      </S.ModalContainer>
     </S.Container>
   );
 };

--- a/client/src/components/MainPage/TaskModal/index.tsx
+++ b/client/src/components/MainPage/TaskModal/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const TaskModal = (props: Props) => {
-  const [tagidx, setTagIdx] = useState<number | undefined>();
+  const [tagidx, setTagIdx] = useState<number | null>(null);
 
   useEffect(() => console.log(tagidx), [tagidx]); // 선택된 tag idx로 변경되는지 test 확인 용 코드
 
@@ -29,7 +29,7 @@ const TaskModal = (props: Props) => {
               <tr>
                 <td>태그</td>
                 <td>
-                  <TagInput setTagIdx={setTagIdx}></TagInput>
+                  <TagInput setTagIdx={setTagIdx} />
                 </td>
               </tr>
               <tr>

--- a/client/src/components/MainPage/TaskModal/style.ts
+++ b/client/src/components/MainPage/TaskModal/style.ts
@@ -3,7 +3,7 @@ import { CgClose } from 'react-icons/cg';
 
 export const Container = styled.div`
   position: absolute;
-  z-index: 999;
+  z-index: 100;
   width: 100vw;
   height: 100%;
   overflow-y: scroll;
@@ -13,7 +13,7 @@ export const Container = styled.div`
   align-items: center;
   transform: translateY(-9.5rem);
 `;
-export const CalendarContainer = styled.div`
+export const ModalContainer = styled.div`
   width: 36.4rem;
   height: 27.4rem;
   background: white;
@@ -38,27 +38,37 @@ export const TaskForm = styled.form``;
 
 export const FormTable = styled.table`
   text-align: left;
+
   td:nth-child(1) {
-    width: 4rem;
+    width: 4.5rem;
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--color-gray7);
   }
   td:nth-child(2) {
-    width: 22rem;
+    width: 24rem;
     height: 2.8rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
+  tr:nth-child(2) {
+    z-index: 999;
+  }
 `;
 
+export const TagInput = styled.div`
+  margin: auto;
+  z-index: 500;
+`;
 export const InputBar = styled.input`
+  margin: auto;
+
   background: var(--color-gray0);
   border: 1px solid var(--color-gray3);
   border-radius: 8px;
   color: black;
-  width: 22rem;
+  width: 22.6rem;
   height: 2.18rem;
   border-radius: 8px;
   font-size: 0.8rem;
@@ -75,7 +85,6 @@ export const InputTimeBar = styled.input`
   border-radius: 8px;
   color: black;
   font-family: inherit;
-
   width: 7rem;
   height: 2.18rem;
   border-radius: 8px;

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -30,4 +30,10 @@ declare module 'GlobalType' {
     done: boolean;
     labels: LabelData[];
   }
+
+  export interface Tag {
+    idx: number;
+    title: string;
+    color: string;
+  }
 }


### PR DESCRIPTION
## 요약
- 태스크 생성 모달 내의 태그 Input 창

## 작동 화면

![Nov-21-2022 21-53-21](https://user-images.githubusercontent.com/73420533/203085029-38bd38e9-921f-461d-a14b-86ebace8474f.gif)

- 태그 Input 바를 클릭 시 태그 리스트가 띄워짐
  - 해당 리스트는 스크롤로 확인
  - 요소 hover 시 background color 변경
  - 요소 클릭 시 해당 요소가 선택됨 
  - 선택된 요소의 x 버튼 클릭 시 선택이 해제되고 초기 상태로 돌아옴

![Nov-21-2022 21-53-53](https://user-images.githubusercontent.com/73420533/203085263-62c8b9e0-dab0-497b-857d-0cf2dbdaf1e5.gif)
- 키보드 입력 시 입력 값의 검색 결과 리스트가 띄워짐
- 결과 외에도 마지막 열의 '생성 : ' 요소를 클릭하면 새로운 요소를 추가할 수 있음 (새로운 tag post)
  - 새로운 요소 추가시 해당 요소가 랜덤 색상과 함께 선택됨 
  - 선택 요소 해제 후 확인되는 리스트에서 태그가 생성되었음을 확인할 수 있음

![Nov-21-2022 21-56-33](https://user-images.githubusercontent.com/73420533/203085618-564b6b0e-8140-4c6d-be0f-0ac32ff8e894.gif)
- 태그 Input 바 클릭 시 리스트 띄워짐
- 태그 Input 바를 제외한 위치를 클릭 시 리스트 사라짐

## 작업 내용
- TagInput 컴포넌트 추가
  - TaskModal 에서 TagInput 컴포넌트 사용
  - TagInput 컴포넌트에서 `태그 선택` 시 TaskModal의 `tagIdx`값에 해당 태그의 idx 저장 ( 현재 test를 위해 해당 값 콘솔에 찍힘 ) 

## 관련 Issue
- #54 
  - 이름이 동일한 태그 생성 가능 여부 논의 중에 있습니다.
  - tag 생성 실패 예외처리 추후 추가

## 비고
- onMouseDown -> onBlur -> onClick 순으로 이벤트가 일어나기 때문에 onMouseDown을 이용했습니다.
- API 연결 완료된 상태입니다.
  - axios.defaults.withCredentials = true; 전역 설정으로 CORS 해결했습니다.
- #56 의 내용이 반영되어야 정상 작동합니다.
