### PR TITLE
[FE] [7-19] 태스크 완료/미완료 filter 기능 구현

### DIFF
--- a/client/src/components/MainPage/MainContents/Log/TaskItem.tsx
+++ b/client/src/components/MainPage/MainContents/Log/TaskItem.tsx
@@ -1,36 +1,44 @@
-import { Task } from 'GlobalType';
+import { Task, CompletionCheckBoxStatus } from 'GlobalType';
 import * as S from './style';
 
 interface taskListProps {
   taskList: Task[];
   activeTask: number | null;
+  completionFilter: CompletionCheckBoxStatus;
 }
 
-const TaskList = ({ taskList, activeTask }: taskListProps) => {
+const TaskList = ({ taskList, activeTask, completionFilter }: taskListProps) => {
+  const isTaskFiltered = (done: boolean) => {
+    if (done && !completionFilter.complete) return true;
+    else if (!done && !completionFilter.incomplete) return true;
+    return false;
+  };
   return (
     <>
       {taskList.map(({ tag_name, idx, title, startedAt, endedAt, importance, location, content, done, isPublic }) => {
         return (
-          <S.TaskItems key={'task' + idx} data-idx={idx} data-tag={tag_name} data-active={idx === activeTask}  done={done}>
-            <S.TaskMainInfos>
-              <S.TaskTime>{startedAt}</S.TaskTime>
-              <S.TaskTitle>{title}</S.TaskTitle>
-              {!isPublic && <S.LockerImage src="./lock.svg" />}
-            </S.TaskMainInfos>
+          !isTaskFiltered(done) && (
+            <S.TaskItem key={'task' + idx} data-idx={idx} data-tag={tag_name} data-active={idx === activeTask} done={done}>
+              <S.TaskMainInfos>
+                <S.TaskTime>{startedAt}</S.TaskTime>
+                <S.TaskTitle>{title}</S.TaskTitle>
+                {!isPublic && <S.LockerImage src="./lock.svg" />}
+              </S.TaskMainInfos>
 
-            {idx === activeTask && (
-              <>
-                <hr />
-                <div>
-                  {startedAt}-{endedAt}
-                </div>
-                <div>{location}</div>
-                <div>{importance}</div>
-                <hr />
-                <div>{content}</div>
-              </>
-            )}
-          </S.TaskItem>
+              {idx === activeTask && (
+                <>
+                  <hr />
+                  <div>
+                    {startedAt}-{endedAt}
+                  </div>
+                  <div>{location}</div>
+                  <div>{importance}</div>
+                  <hr />
+                  <div>{content}</div>
+                </>
+              )}
+            </S.TaskItem>
+          )
         );
       })}
     </>

--- a/client/src/components/MainPage/MainContents/Log/index.tsx
+++ b/client/src/components/MainPage/MainContents/Log/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import TaskList from './TaskItem';
-import { Task } from 'GlobalType';
+import { Task, CompletionCheckBoxStatus } from 'GlobalType';
 import { dummyTaskList } from '../../../common/dummy';
 import * as S from './style';
 
@@ -10,6 +10,7 @@ const Log = () => {
   const [taskList, setTaskList] = useState<Task[]>(dummyTaskList);
   const [activeTask, setActiveTag] = useState<number | null>(null);
   const [timeMarkerData, setTimeMarkerData] = useState<number[]>([0, 0]);
+  const [completionCheckBoxStatus, setCompletionCheckBoxStatus] = useState<CompletionCheckBoxStatus>({ complete: true, incomplete: true });
   const selectedRef = useRef<HTMLDivElement | null>(null);
   const mouseOffsetRef = useRef<number[]>([0, 0]);
   const taskContainerRef = useRef<HTMLDivElement | null>(null);
@@ -96,6 +97,14 @@ const Log = () => {
     setSelectedElement(null);
   };
 
+  const handleCheckBoxChange = (e: React.ChangeEvent, type: string) => {
+    if (!(e.target instanceof HTMLInputElement)) return;
+    const isCompleteCheckBox = type === 'complete';
+    const isChecked = e.target.checked;
+    if (isCompleteCheckBox) setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, complete: isChecked });
+    else setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, incomplete: isChecked });
+  };
+
   useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseup', handleMouseUp);
@@ -114,7 +123,6 @@ const Log = () => {
       )}
       <S.LogTitle>LOG</S.LogTitle>
       <S.LogContainer>
-        <S.SlideObserver data-direction="left" direction="left"></S.SlideObserver>
         <S.TimeBarSection>
           <img src="./timebar-clock.svg" alt="TimeBar" />
           <S.TimeBar>
@@ -128,21 +136,27 @@ const Log = () => {
             <option value="importance">중요도순</option>
           </S.SortOptionSelect>
           <S.DateController>{'< 11.12 >'}</S.DateController>
-          <div></div>
+          <S.CheckBoxContainer>
+            <S.CheckBoxLabel htmlFor="complete">완료</S.CheckBoxLabel>
+            <S.Test type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />
+            <S.CheckBoxLabel htmlFor="incomplete">미완료</S.CheckBoxLabel>
+            <S.Test type="checkbox" id="incomplete" defaultChecked={completionCheckBoxStatus.incomplete} onChange={(e) => handleCheckBoxChange(e, 'incomplete')} />
+          </S.CheckBoxContainer>
         </S.LogNavBarSection>
         <S.LogMainSection ref={taskContainerRef}>
+          <S.SlideObserver data-direction="left" direction="left"></S.SlideObserver>
           {tagList.map((tag) => {
             return (
               <>
                 <S.TagWrap key={tag} data-tag={tag} onClick={handleTagWrapClick} onMouseDown={handleMouseDown}>
                   <S.TagTitle data-tag={tag}>#{tag}</S.TagTitle>
-                  <TaskList taskList={filteredTasks(tag)} activeTask={activeTask} />
+                  <TaskList taskList={filteredTasks(tag)} activeTask={activeTask} completionFilter={completionCheckBoxStatus} />
                 </S.TagWrap>
               </>
             );
           })}
+          <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
         </S.LogMainSection>
-        <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
       </S.LogContainer>
     </>
   );

--- a/client/src/components/MainPage/MainContents/Log/index.tsx
+++ b/client/src/components/MainPage/MainContents/Log/index.tsx
@@ -99,10 +99,8 @@ const Log = () => {
 
   const handleCheckBoxChange = (e: React.ChangeEvent, type: string) => {
     if (!(e.target instanceof HTMLInputElement)) return;
-    const isCompleteCheckBox = type === 'complete';
     const isChecked = e.target.checked;
-    if (isCompleteCheckBox) setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, complete: isChecked });
-    else setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, incomplete: isChecked });
+    setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, [type]: isChecked });
   };
 
   useEffect(() => {
@@ -138,9 +136,9 @@ const Log = () => {
           <S.DateController>{'< 11.12 >'}</S.DateController>
           <S.CheckBoxContainer>
             <S.CheckBoxLabel htmlFor="complete">완료</S.CheckBoxLabel>
-            <S.Test type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />
+            <S.CheckBox type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />
             <S.CheckBoxLabel htmlFor="incomplete">미완료</S.CheckBoxLabel>
-            <S.Test type="checkbox" id="incomplete" defaultChecked={completionCheckBoxStatus.incomplete} onChange={(e) => handleCheckBoxChange(e, 'incomplete')} />
+            <S.CheckBox type="checkbox" id="incomplete" defaultChecked={completionCheckBoxStatus.incomplete} onChange={(e) => handleCheckBoxChange(e, 'incomplete')} />
           </S.CheckBoxContainer>
         </S.LogNavBarSection>
         <S.LogMainSection ref={taskContainerRef}>

--- a/client/src/components/MainPage/MainContents/Log/style.ts
+++ b/client/src/components/MainPage/MainContents/Log/style.ts
@@ -223,7 +223,7 @@ export const CheckBoxLabel = styled.label`
   font-size: 0.75rem;
 `;
 
-export const Test = styled.input`
+export const CheckBox = styled.input`
   width: 0.625rem;
   margin-right: 0.25rem;
   border-radius: 0.5rem;

--- a/client/src/components/MainPage/MainContents/Log/style.ts
+++ b/client/src/components/MainPage/MainContents/Log/style.ts
@@ -62,6 +62,7 @@ export const LogNavBarSection = styled.div`
   width: 100%;
   height: 100%;
   padding-bottom: 0.5rem;
+  padding-right: 1rem;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
@@ -71,12 +72,13 @@ export const LogNavBarSection = styled.div`
 `;
 
 export const SortOptionSelect = styled.select`
+  margin-right: 1.25rem;
   border-radius: 0.5rem;
   margin-left: 1rem;
   color: #616161;
   font-size: 0.825rem;
-  font-family: 'Noto Sans KR', sans-serif;
   text-align: center;
+  font-family: 'Noto Sans KR', sans-serif;
   option {
     color: #616161;
     font-size: 0.625rem;
@@ -208,4 +210,22 @@ export const LockerImage = styled.img`
 export const TaskMainInfos = styled.div`
   display: flex;
   align-items: center;
+`;
+
+export const CheckBoxContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const CheckBoxLabel = styled.label`
+  color: #616161;
+  font-family: 'Noto Sans KR', sans-serif;
+  font-size: 0.75rem;
+`;
+
+export const Test = styled.input`
+  width: 0.625rem;
+  margin-right: 0.25rem;
+  border-radius: 0.5rem;
+  accent-color: #7991db;
 `;

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -30,4 +30,8 @@ declare module 'GlobalType' {
     done: boolean;
     labels: LabelData[];
   }
+  export interface CompletionCheckBoxStatus {
+    complete: boolean;
+    incomplete: boolean;
+  }
 }


### PR DESCRIPTION
## 요약
체크박스 기반으로 하여 완료/미완료를 선택가능하며 선택한 옵션의 task만 볼 수 있습니다.

## 작동 화면
![GIF 2022-11-22 오전 2-26-33](https://user-images.githubusercontent.com/109147404/203121402-ab0965ee-95ed-4249-9c31-c87ee767fcc0.gif)


## 작업 내용
1. 완료/미완료 체크박스 버튼을 만들었습니다.
2. 완료/미완료 체크박스 상태를 useState로 관리합니다.
3. 완료/미완료 체크박스 상태와, task의 완료 여부를 나타내는 done 값에 따라 각 task의 render 여부를 결정합니다.
4. 라디오박스 추가에 따라 일부 기존 element에 CSS 수정이 있습니다.

## 관련 Issue
- 7-19

## 비고
