### PR TITLE
[BE] [7-17] 비정상적인 요청 시 에러 코드 응답을 위해 쿼리 실행 함수에서 try-catch 제거

### DIFF
--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -8,6 +8,7 @@ import { executeSql } from '../db';
 import jwt from 'jsonwebtoken';
 import { AuthorizedRequest } from '../types';
 import crypto from 'crypto';
+import { RowDataPacket } from 'mysql2';
 
 const router = express.Router();
 
@@ -77,11 +78,11 @@ router.post('/login', async (req, res) => {
   const { userId, password } = req.body;
   if (!(userId && password)) return res.sendStatus(400);
   let user;
-  [user] = await executeSql('select * from user where user_id = ?', [userId]);
+  [user] = (await executeSql('select * from user where user_id = ?', [userId])) as RowDataPacket[];
   if (!user) return res.status(401).json({ msg: '아이디 또는 비밀번호가 틀렸어요.' });
 
   const encrypted = encrypt(password, user.salt);
-  [user] = await executeSql('select * from user where user_id = ? and password = ?', [userId, encrypted]);
+  [user] = (await executeSql('select * from user where user_id = ? and password = ?', [userId, encrypted])) as RowDataPacket[];
   if (!user) return res.status(401).json({ msg: '아이디 또는 비밀번호가 틀렸어요.' });
 
   const token = generateAccessToken({ userIdx: user.idx });
@@ -108,7 +109,7 @@ router.get('/login/:oauth_type/callback', async (req, res) => {
   const accessToken = await httpGetAccessToken(oauthType, code);
   const oauthEmail = await httpGetOAuthUserIdentifier(oauthType, accessToken); // 변수 이름. (카카오에서는 이메일 얻기 위해 검수 필요)
 
-  const [user] = await executeSql('select * from user where oauth_type = ? and oauth_email = ?', [oauthType, oauthEmail]);
+  const [user] = (await executeSql('select * from user where oauth_type = ? and oauth_email = ?', [oauthType, oauthEmail])) as RowDataPacket[];
   const token = generateAccessToken(user ? { userIdx: user.idx } : { oauthType, oauthEmail });
 
   res.cookie('token', token, {
@@ -136,13 +137,13 @@ router.post('/signup', async (req, res) => {
     if (!(oauthType && oauthEmail)) return res.status(401).send({ msg: '잘못된 토큰이에요.' });
     if (!validateOAuthType(oauthType)) return res.status(401).send({ msg: '잘못된 토큰이에요.' });
 
-    [user] = await executeSql('select * from user where oauth_type = ? and oauth_email = ?', [oauthType, oauthEmail]);
+    [user] = (await executeSql('select * from user where oauth_type = ? and oauth_email = ?', [oauthType, oauthEmail])) as RowDataPacket[];
     if (user) {
       return res.status(409).json({ msg: '해당 이메일은 이미 가입되어 있어요.' });
     }
   }
 
-  [user] = await executeSql('select * from user where user_id = ?', [userId]);
+  [user] = (await executeSql('select * from user where user_id = ?', [userId])) as RowDataPacket[];
   if (user) {
     console.log(`ID 중복: ${userId}`);
     return res.status(409).json({ msg: '이미 존재하는 아이디예요.' });

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { OkPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -14,8 +15,12 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color } = req.body;
-  const result = await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx]);
-  res.status(200).send({ idx: result.insertId });
+  try {
+    const result = (await executeSql('insert into tag (title, color, user_idx) values (?, ?, ?)', [title, color, userIdx])) as OkPacket;
+    res.status(200).send({ idx: result.insertId });
+  } catch {
+    res.sendStatus(409);
+  }
 });
 
 export default router;

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const tags = await executeSql('select idx, title, color from tag where user_idx = ?', [userIdx.toString()]);
+  const tags = await executeSql('select tag.idx as idx, tag.title as title, tag.color as color, count(task.idx) as count from tag left join task on task.tag_idx = tag.idx where tag.user_idx = ? group by tag.idx', [userIdx.toString()]);
   res.json(tags);
 });
 

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { OkPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -31,7 +32,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   if (!validateLongitude(lng)) res.sendStatus(400);
 
   try {
-    const result = await executeSql('insert into task (title, importance, date, started_at, ended_at, lat, lng, content, done, public, tag_idx, user_idx) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+    const result = (await executeSql('insert into task (title, importance, date, started_at, ended_at, lat, lng, content, done, public, tag_idx, user_idx) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
       title,
       importance,
       date,
@@ -44,7 +45,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
       isPublic,
       tagIdx,
       userIdx,
-    ]);
+    ])) as OkPacket;
 
     const taskIdx = result.insertId;
     await Promise.all(

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -14,7 +14,7 @@ const executeSql = async (sql: string, values?: string[]) => {
     const [rows] = await pool.execute(sql, values);
     return rows;
   } catch (err) {
-    return err;
+    throw err;
   }
 };
 


### PR DESCRIPTION
## 요약
쿼리 실행을 추상화한 함수 `executeSql`에서 error를 catch하는 동작을 제거했습니다.
## 작동 화면
[cf6110ac-852e-414b-8570-760982986924.webm](https://user-images.githubusercontent.com/55306894/203225804-4d63e174-ab7f-457c-aed8-2c01de7f3c73.webm)
