### PR TITLE
[FE] [7-15] task 생성 모달 더보기 기능 추가

### DIFF
--- a/client/src/components/TaskModal/TaskModal.style.ts
+++ b/client/src/components/TaskModal/TaskModal.style.ts
@@ -13,13 +13,15 @@ export const Container = styled.div`
   align-items: center;
   transform: translateY(-9.5rem);
 `;
-export const ModalContainer = styled.div`
+export const ModalContainer = styled.div<{ isDetailOpen: boolean }>`
+  position: relative; // button 위치고정을 위해
   width: 36.4rem;
-  height: 27.4rem;
+  height: 30.4rem;
+  ${(props) => props.isDetailOpen && 'height : 44rem;'};
+  transition: height 0.3s;
   background: white;
   border-radius: 1rem;
   box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
-
   display: flex;
   flex-direction: column;
   justify-content: top;
@@ -79,6 +81,24 @@ export const InputBar = styled.input`
   }
 `;
 
+export const InputArea = styled.textarea`
+  margin: auto;
+
+  background: var(--color-gray0);
+  border: 1px solid var(--color-gray3);
+  border-radius: 8px;
+  color: black;
+  width: 22.6rem;
+  height: 2.66rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  ::placeholder {
+    font-size: 0.8rem;
+    color: var(--color-gray2);
+  }
+`;
+
 export const InputTimeBar = styled.input`
   background: var(--color-gray0);
   border: 1px solid var(--color-gray3);
@@ -104,11 +124,16 @@ export const InputTimeBar = styled.input`
     color: #a3a3a3;
   }
 `;
+
+export const DetailButton = styled.div`
+  cursor: pointer;
+`;
 export const Border = styled.div`
   width: 28rem;
   h4 {
-    color: var(--color-gray7);
-    margin: 0.8rem;
+    color: var(--color-gray6);
+    margin-top: 0.5rem;
+    margin-bottom: 1.1rem;
     overflow: hidden;
     text-align: center;
     font-weight: 600;
@@ -142,5 +167,20 @@ export const CloseButton = styled(CgClose)`
   top: 1.1rem;
   color: var(--color-gray6);
   margin: 3px;
+  cursor: pointer;
+`;
+
+export const SubmitButton = styled.button`
+  background: var(--color-main);
+  position: absolute;
+  bottom: 1.6rem;
+  font-family: 'Press Start 2P', cursive;
+  height: 2.3rem;
+  border: 0px;
+  border-radius: 3rem;
+  color: white;
+  width: 24rem;
+  margin: 2rem;
+  font-size: 0.8rem;
   cursor: pointer;
 `;

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -2,9 +2,7 @@ import React, { useEffect, useState } from 'react';
 import * as S from './TaskModal.style';
 import ImportanceInput from './ImportanceInput';
 import TagInput from './TagInput';
-import LocationInput from './LocationInput';
 import useInput from '../../hooks/useInput';
-//import { Location } from 'GlobalType';
 
 interface Props {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -14,11 +12,6 @@ const TaskModal = (props: Props) => {
   const [locationObject, setLocationObject] = useState<Location | null>(null); // { location, lng, lat }
 
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-
-  // useEffect(() => {
-  //   console.log(tagidx);
-  //   console.log(locationObject);
-  // }, [tagidx, locationObject]); // 입력된 요소로 변경되는지 test 확인 용 코드
 
   return (
     <S.Container>

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -2,19 +2,27 @@ import React, { useEffect, useState } from 'react';
 import * as S from './TaskModal.style';
 import ImportanceInput from './ImportanceInput';
 import TagInput from './TagInput';
+import LocationInput from './LocationInput';
 import useInput from '../../hooks/useInput';
+//import { Location } from 'GlobalType';
 
 interface Props {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const TaskModal = (props: Props) => {
   const [tagidx, setTagIdx] = useState<number | null>(null);
+  const [locationObject, setLocationObject] = useState<Location | null>(null); // { location, lng, lat }
 
-  useEffect(() => console.log(tagidx), [tagidx]); // 선택된 tag idx로 변경되는지 test 확인 용 코드
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+
+  // useEffect(() => {
+  //   console.log(tagidx);
+  //   console.log(locationObject);
+  // }, [tagidx, locationObject]); // 입력된 요소로 변경되는지 test 확인 용 코드
 
   return (
     <S.Container>
-      <S.ModalContainer>
+      <S.ModalContainer isDetailOpen={isDetailOpen}>
         {' '}
         <S.CloseButton onClick={(e) => props.setIsModalOpen(false)} />
         <S.Date>{'• 11.12 •'}</S.Date>
@@ -55,10 +63,35 @@ const TaskModal = (props: Props) => {
               </tr>
             </tbody>
           </S.FormTable>
+          <S.DetailButton onClick={() => setIsDetailOpen(!isDetailOpen)}>
+            <S.Border>
+              <h4>{isDetailOpen ? '닫기 ▲' : '더보기  ▼'}</h4>
+            </S.Border>
+          </S.DetailButton>
+          {isDetailOpen && (
+            <S.FormTable>
+              <tbody>
+                <tr>
+                  <td>위치</td>
+                  <td>
+                    <S.InputBar />
+                  </td>
+                </tr>
+                <tr>
+                  <td>라벨</td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>메모</td>
+                  <td>
+                    <S.InputArea />
+                  </td>
+                </tr>
+              </tbody>
+            </S.FormTable>
+          )}
         </S.TaskForm>
-        <S.Border>
-          <h4>{'더보기  ▼'}</h4>
-        </S.Border>
+        <S.SubmitButton>NEW TASK!</S.SubmitButton>
       </S.ModalContainer>
     </S.Container>
   );


### PR DESCRIPTION
## 요약
- task 생성 모달의 더보기 버튼 활성화

## 작동 화면
 
![Nov-22-2022 18-29-38](https://user-images.githubusercontent.com/73420533/203277595-8175a29c-1894-4844-a77c-f006623bf17f.gif)

- 더보기 버튼을 누르면 추가 정보 입력 폼이 표시된다.
- 닫기 버튼을 누르면 초기 상태로 돌아온다.

## 작업 내용
1. isDetailOpen 상태값을 통해 더보기 버튼 활성화
2. 메모 입력 란에 다중 줄 text 입력 바 추가

## 비고
위치 / 라벨은 추가 pr로 올릴 예정입니다.
