### PR TITLE
[FE/BE] [2-4] 프로필 사진 업로드 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 !.env.example
 build
+uploads/

--- a/client/src/components/SignupMenu/SignupMenu.tsx
+++ b/client/src/components/SignupMenu/SignupMenu.tsx
@@ -2,21 +2,30 @@ import React, { useState } from 'react';
 import * as S from './SignupMenu.style';
 import { Link, useNavigate } from 'react-router-dom';
 import { DEFAULT_PROFILE_IMG_URL, HOST } from '../../constants';
-import { useForm } from 'react-hook-form';
+import { FieldValues, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 
-const httpPostSignup = async ({ userId, password, username }: any) => {
+const httpPostSignup = async ({ userId, password, username, profileImg }: SignupFormSubmit) => {
+  const formData = new FormData();
+  formData.append('userId', userId);
+  formData.append('password', password);
+  formData.append('username', username);
+  formData.append('profileImg', profileImg[0]);
   const response = await fetch(`${HOST}/api/v1/auth/signup`, {
     method: 'post',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ userId, password, username }),
+    body: formData,
   });
   return response;
 };
+
+interface SignupFormSubmit {
+  userId: string;
+  password: string;
+  username: string;
+  profileImg: FileList;
+}
 
 const SignupMenu = () => {
   const [profileImg, setProfileImg] = useState<File>();
@@ -46,8 +55,8 @@ const SignupMenu = () => {
     }
   };
 
-  const signupFormSubmit = async (d: any) => {
-    const response = await httpPostSignup(d);
+  const signupFormSubmit = async ({ userId, password, username, profileImg }: FieldValues) => {
+    const response = await httpPostSignup({ userId, password, username, profileImg });
     if (response.ok) {
       navigate('/');
     } else {
@@ -64,7 +73,7 @@ const SignupMenu = () => {
           <S.ProfileImage>
             <img src={profileImg ? URL.createObjectURL(profileImg) : DEFAULT_PROFILE_IMG_URL} alt="profile-img" />
             <S.EditRound>
-              <input type="file" onChange={handleProfileImageChange} />
+              <input {...register('profileImg')} type="file" onChange={handleProfileImageChange} />
               <S.EditIcon />
             </S.EditRound>
           </S.ProfileImage>

--- a/client/src/components/SignupMenu/SignupMenu.tsx
+++ b/client/src/components/SignupMenu/SignupMenu.tsx
@@ -6,26 +6,26 @@ import { FieldValues, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 
-const httpPostSignup = async ({ userId, password, username, profileImg }: SignupFormSubmit) => {
-  const formData = new FormData();
-  formData.append('userId', userId);
-  formData.append('password', password);
-  formData.append('username', username);
-  formData.append('profileImg', profileImg[0]);
-  const response = await fetch(`${HOST}/api/v1/auth/signup`, {
-    method: 'post',
-    credentials: 'include',
-    body: formData,
-  });
-  return response;
-};
-
-interface SignupFormSubmit {
+interface SignupData {
   userId: string;
   password: string;
   username: string;
   profileImg: FileList;
 }
+
+const httpPostSignup = async ({ userId, password, username, profileImg }: SignupData) => {
+  const signupFormData = new FormData();
+  signupFormData.append('userId', userId);
+  signupFormData.append('password', password);
+  signupFormData.append('username', username);
+  signupFormData.append('profileImg', profileImg[0]);
+  const response = await fetch(`${HOST}/api/v1/auth/signup`, {
+    method: 'post',
+    credentials: 'include',
+    body: signupFormData,
+  });
+  return response;
+};
 
 const SignupMenu = () => {
   const [profileImg, setProfileImg] = useState<File>();

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -6,7 +6,7 @@ import { authenticateToken, generateAccessToken } from '../utils/auth';
 import { generateUnionTypeChecker } from '../utils/validate';
 import { executeSql } from '../db';
 import jwt from 'jsonwebtoken';
-import { AuthorizedRequest } from '../types';
+import { AuthorizedRequest, SignupRequest } from '../types';
 import crypto from 'crypto';
 import fileUpload from 'express-fileupload';
 
@@ -125,7 +125,7 @@ router.get('/login/:oauth_type/callback', async (req, res) => {
   res.redirect(`${CLIENT}/${user ? 'main' : 'signup'}`);
 });
 
-router.post('/signup', async (req: any, res) => {
+router.post('/signup', async (req: SignupRequest, res) => {
   const { userId, password, username } = req.body;
   let profileImgFilename = '';
   if (req.files) {

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -8,8 +8,15 @@ import { executeSql } from '../db';
 import jwt from 'jsonwebtoken';
 import { AuthorizedRequest } from '../types';
 import crypto from 'crypto';
+import fileUpload from 'express-fileupload';
 
 const router = express.Router();
+
+router.use(
+  fileUpload({
+    createParentPath: true,
+  })
+);
 
 const generateSalt = () => {
   return crypto.randomBytes(64).toString('hex');
@@ -118,12 +125,16 @@ router.get('/login/:oauth_type/callback', async (req, res) => {
   res.redirect(`${CLIENT}/${user ? 'main' : 'signup'}`);
 });
 
-router.post('/signup', async (req, res) => {
+router.post('/signup', async (req: any, res) => {
   const { userId, password, username } = req.body;
-  const profileImg = 'profile'; // TODO: multer
-  // req.file.filename;
+  let profileImgFilename = '';
+  if (req.files) {
+    const { profileImg } = req.files;
+    profileImgFilename = profileImg.name; // TODO: 해시하기
+    profileImg.mv('./uploads/' + profileImgFilename);
+  }
 
-  if (!(userId && password && username && profileImg)) return res.sendStatus(400);
+  if (!(userId && password && username)) return res.sendStatus(400);
   // TODO: 유효성 검증
 
   const token = req.cookies.token;
@@ -151,8 +162,8 @@ router.post('/signup', async (req, res) => {
   const salt = generateSalt();
   const encrypted = encrypt(password, salt);
   await (oauthType
-    ? executeSql('insert into `user` (user_id, password, username, oauth_type, oauth_email, salt) values (?, ?, ?, ?, ?, ?)', [userId, encrypted, username, oauthType, oauthEmail, salt])
-    : executeSql('insert into `user` (user_id, password, username, salt) values (?, ?, ?, ?)', [userId, encrypted, username, salt]));
+    ? executeSql('insert into `user` (user_id, password, username, profile_img, oauth_type, oauth_email, salt) values (?, ?, ?, ?, ?, ?, ?)', [userId, encrypted, username, profileImgFilename, oauthType, oauthEmail, salt])
+    : executeSql('insert into `user` (user_id, password, username, profile_img, salt) values (?, ?, ?, ?, ?)', [userId, encrypted, username, profileImgFilename, salt]));
   console.log(`회원가입 성공: ${userId}, ${username}`);
   res.sendStatus(201);
 });

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -7,3 +7,19 @@ declare interface AuthorizedRequest extends Request {
     oauthEmail?: string;
   };
 }
+
+declare interface SignupRequest extends Request {
+  files?: {
+    profileImg: {
+      name: string;
+      data: Buffer;
+      size: number;
+      encoding: string;
+      tempFilePath: string;
+      truncated: boolean;
+      mimetype: string;
+      md5: string;
+      mv: Function;
+    };
+  };
+}


### PR DESCRIPTION
## 요약
- 회원가입 페이지에서 업로드한 파일이 서버 컴퓨터에 파일 형태로 저장됩니다.
## 작동 화면
[c01262e8-2418-4c99-a9e6-0a984491e038.webm](https://user-images.githubusercontent.com/55306894/203258581-c7b427fd-03f7-445c-927f-1554bdb2576c.webm)


## 작업 내용
1. API 수정
2. 클라이언트에서 회원가입 요청을 보내는 코드 수정

## 테스트 방법
1. 로컬 환경에서 테스트해주세요.
2. 회원가입 시 프로필 사진을 업로드하세요.
3. 나머지 필드를 채우고 회원가입을 완료해주세요.
4. `server/upload/`에 업로드한 이미지 파일이 생겼는지 확인하세요.