### PR TITLE
[BE] [7-17] tag 삭제 API

### DIFF
--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -18,4 +18,16 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   res.status(200).send({ idx: result.insertId });
 });
 
+router.delete('/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const tagIdx = req.params.tag_idx;
+
+  try {
+    await executeSql('delete from tag where user_idx = ? and idx = ?', [userIdx.toString(), tagIdx]);
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(403);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## 요약
자신의 태그를 삭제하는 API를 작성했습니다.
## 작동 화면
[9a738151-d93e-4b36-ba52-7c3561bdbb9b.webm](https://user-images.githubusercontent.com/55306894/203259687-19be5bdc-981b-4b9d-84a4-dc21554766d0.webm)
## 테스트 방법
1. `http://localhost:8000/api/v1/tag`에 접속하면 자신의 태그를 확인할 수 있습니다.
2. 자신의 태그 중 삭제하길 원하는 태그의 인덱스 `n`에 대해 콘솔에 다음 명령어를 입력하세요.
```
fetch(`http://localhost:8000/api/v1/tag/${n}`, {
  method: 'delete',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  }
});
```
3. 페이지를 새로고침하세요.