### PR TITLE
[BE] [4-9] 친구 추가를 위한 유저 검색 API 구현

### DIFF
--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -3,6 +3,7 @@ import authRouter from './auth';
 import taskRouter from './task';
 import labelRouter from './label';
 import tagRouter from './tag';
+import userRouter from './user';
 
 const router = express.Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRouter);
 router.use('/task', taskRouter);
 router.use('/label', labelRouter);
 router.use('/tag', tagRouter);
+router.use('/user', userRouter);
 
 export default router;

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/', authenticateToken, async (req, res) => {
+  const userId = `%${req.query.user_id}%`;
+  const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ?', [userId]);
+  res.json(users);
+});
+
+export default router;

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -8,8 +8,12 @@ const router = Router();
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const userId = `%${req.query.user_id}%`;
-  const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx.toString()]);
-  res.json(users);
+  try {
+    const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx.toString()]);
+    res.json(users);
+  } catch {
+    res.sendStatus(500);
+  }
 });
 
 export default router;

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { executeSql } from '../db';
-import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
 
 const router = Router();

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
 
 const router = Router();
 
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
   const userId = `%${req.query.user_id}%`;
-  const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ?', [userId]);
+  const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx.toString()]);
   res.json(users);
 });
 


### PR DESCRIPTION
## 요약
친구 추가 시 유저의 아이디를 통해 유저를 검색할 수 있도록 하기 위한 API를 구현하였습니다.
검색 키워드를 포함하는 id를 모두 결과에 포함시켰습니다.
만약 `abc`라는 id를 가진 유저가 존재하고 `bc`라는 키워드를 통해 유저를 검색하였다면 `abc` 유저 또한 검색 결과에 포함됩니다.

## 작동 화면
<img width="650" alt="image" src="https://user-images.githubusercontent.com/92143119/203389830-0dd7ca56-d180-4382-9197-bbb921fd4fbd.png">


## 작업 내용
1. user route 설정
2. 유저 검색 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/user?user_id={검색하고 싶은 id}`을 입력합니다.

## 관련 Task
- 4-9