### PR TITLE
[BE] [4-10] 친구 목록 조회 API 구현

### DIFF
--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -7,12 +7,10 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const accepted = req.query.accepted === 'true' ? 1 : 0;
-  const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = ?', [
+  const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true', [
     userIdx.toString(),
     userIdx.toString(),
     userIdx.toString(),
-    accepted.toString(),
   ]);
   res.json(users);
 });

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const accepted = req.query.accepted === 'true' ? 1 : 0;
+  const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = ?', [
+    userIdx.toString(),
+    userIdx.toString(),
+    userIdx.toString(),
+    accepted.toString(),
+  ]);
+  res.json(users);
+});
+
+export default router;

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -7,12 +7,16 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true', [
-    userIdx.toString(),
-    userIdx.toString(),
-    userIdx.toString(),
-  ]);
-  res.json(users);
+  try {
+    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true', [
+      userIdx.toString(),
+      userIdx.toString(),
+      userIdx.toString(),
+    ]);
+    res.json(users);
+  } catch {
+    res.sendStatus(500);
+  }
 });
 
 export default router;

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -4,6 +4,7 @@ import taskRouter from './task';
 import labelRouter from './label';
 import tagRouter from './tag';
 import userRouter from './user';
+import friendRouter from './friend';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/task', taskRouter);
 router.use('/label', labelRouter);
 router.use('/tag', tagRouter);
 router.use('/user', userRouter);
+router.use('/friend', friendRouter);
 
 export default router;

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -3,6 +3,7 @@ import authRouter from './auth';
 import taskRouter from './task';
 import labelRouter from './label';
 import tagRouter from './tag';
+import userRouter from './user';
 
 const router = express.Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRouter);
 router.use('/task', taskRouter);
 router.use('/label', labelRouter);
 router.use('/tag', tagRouter);
+router.use('/user', userRouter);
 
 export default router;

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/', authenticateToken, async (req, res) => {
+  const userId = `%${req.query.user_id}%`;
+  const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ?', [userId]);
+  res.json(users);
+});
+
+export default router;

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { executeSql } from '../db';
-import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
 
 const router = Router();


### PR DESCRIPTION
## 요약
친구 목록을 조회할 수 있는 API를 구현하였습니다.
~~해당 API를 통해 친구 목록과 친구 요청 목록을 모두 조회할 수 있게 하기 위해 `accepted`를 입력 받아 `accepted=true`이면 친구 목록을, `accepted=false`이면 친구 요청 목록을 조회할 수 있게 하였습니다.~~
친구 목록과 친구 요청 목록을 조회하는 API를 분리하기로 하여 위 내용은 삭제합니다.

## 작동 화면
<img width="505" alt="image" src="https://user-images.githubusercontent.com/92143119/203459277-4db1d95b-38e0-4ec2-87f5-55bf29afdc90.png">

## 작업 내용
1. friend route 설정
2. 친구 목록 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/friend`를 입력합니다.

## 관련 Task
- 4-10

## 비고
branch 생성을 4-9 branch에서 해버려서 4-9 내용이 이 PR에 포함되어 버렸습니다..!
`friend.ts` 부분만 봐주시면 될 것 같습니다