### PR TITLE
[BE] [7-17] 태그 컬러 수정 API 추가

### DIFF
--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -23,6 +23,18 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
+router.post('/color/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const tagIdx = req.params.tag_idx;
+  const { color } = req.body;
+  try {
+    const result = await executeSql('update tag set color = ? where idx = ? and user_idx = ?', [color, tagIdx, userIdx]);
+    res.status(200);
+  } catch {
+    res.sendStatus(403);
+  }
+});
+
 router.delete('/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const tagIdx = req.params.tag_idx;


### PR DESCRIPTION
## 요약
태그의 컬러를 수정하는 API 입니다.

## 작업 내용
1. 로그인 후 다음 명령어로 작동 확인할 수 있습니다.
```
fetch('http://localhost:8000/api/v1/tag/color/${tag_idx}', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({ color: '#dddfff'}),
});
```

## 비고
- API 문서에 추가했습니다.
- CORS 오류로 인해 POST 방식으로 진행했습니다.
- 에러코드 분류에 대한 기준을 공유해주셨으면 좋겠습니다.