### PR TITLE
[BE] [4-15] 친구 요청 목록 조회 API 구현

### DIFF
--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -19,4 +19,14 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
+router.get('/request', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  try {
+    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx.toString()]);
+    res.json(users);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## 요약
사용자에게 온 친구 요청의 목록을 조회하는 API를 구현하였습니다.
결과값 : `[{idx, user_id, username, profile_img}]` (친구 요청을 보낸 사용자 객체 배열)

## 작동 화면
<img width="543" alt="스크린샷 2022-11-23 오후 1 55 37" src="https://user-images.githubusercontent.com/92143119/203472110-aafec238-a3e4-4859-a969-c30238e9526e.png">

## 작업 내용
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/friend/request`를 입력합니다.

## 관련 Task
- 4-15

## 비고
기존 API 문서에서 해당 API 요청 URL이 `/friend/req`였는데 줄임말을 사용하는 것의 이점이 없는 같아 `friend/request`로 변경하였습니다. API 문서 함께 참고 부탁드립니다.