### PR TITLE
[BE] [4-13] 친구 삭제 API 구현

### DIFF
--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -24,6 +25,24 @@ router.get('/request', authenticateToken, async (req: AuthorizedRequest, res) =>
   try {
     const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx.toString()]);
     res.json(users);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+router.delete('/:user_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const friendIdx = req.params.user_idx;
+  try {
+    const { affectedRows } = (await executeSql('delete from friendship where ((sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)) and accepted = true', [
+      userIdx.toString(),
+      friendIdx.toString(),
+      friendIdx.toString(),
+      userIdx.toString(),
+    ])) as RowDataPacket;
+
+    if (affectedRows === 0) return res.status(404).json({ msg: '존재하지 않는 친구예요.' });
+    res.sendStatus(200);
   } catch {
     res.sendStatus(500);
   }


### PR DESCRIPTION
## 요약
친구를 삭제하는 API를 구현하였습니다.
- 요청 URL : `/friend/:user_idx`
   - `user_idx` : 삭제하고 싶은 친구의 idx
- 응답
   - 삭제 성공 : `200`
   - 해당 친구가 존재하지 않아 삭제 불가 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 실행 과정
1. `/friend`를 통해 친구 목록 확인
2. 개발자 도구 콘솔에 아래의 명령어 입력 후 실행
   ```js
   fetch('http://localhost:8000/api/v1/friend/12', {
     method: 'delete',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     }
   });
   ```
3. `/friend`를 통해 친구 목록을 확인하여 삭제가 완료되었음을 확인

[8290ffe6-d94b-42bb-a1f6-32a3d82e5edf.webm](https://user-images.githubusercontent.com/92143119/203488607-089bae59-188c-4a25-a335-a241d077e5c3.webm)

## 작업 내용
1. 친구 삭제 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/friend/${user_idx}', {
     method: 'delete',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     }
   });
   ```

## 관련 Task
- 4-13
