### PR TITLE
[FE] [7-18] tagInput 태그 삭제, 색상 변경 기능 추가 / 오류수정 및 리팩토링

### DIFF
--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -9,44 +9,46 @@ import { Tag } from 'GlobalType';
 axios.defaults.withCredentials = true; // withCredentials 전역 설정
 
 interface TagInputProps {
-  setTagIdx: React.Dispatch<React.SetStateAction<number | null>>;
+  tagObject: Tag | null;
+  setTagObject: React.Dispatch<React.SetStateAction<Tag | null>>;
 }
 
-const TagInput = ({ setTagIdx }: TagInputProps) => {
+const TagInput = ({ tagObject, setTagObject }: TagInputProps) => {
+  const [isTagInputFocused, setIsTagInputFocused] = useState(false);
+  const [tagInput, onChangeTagInput, setTagInput] = useInput('');
   const [tagList, setTagList] = useState<Tag[]>([]);
-  const [tagInput, onTagInputChange, setTagInput] = useInput('');
-  const [selectedTag, setSelectedTag] = useState<Tag | null>(); // 선택된 하나의 태그
-  const [isTagInputFocused, setIsTagInputFocused] = useState<Boolean>(false); // Input창이 Focus될 때만 List 표시
-  const [newTagColor, setNewTagColor] = useState(''); // 새로운 Tag 추가 시 색깔 랜덤 배정
+  const [searchedTagList, setSearchedTagList] = useState<Tag[]>([]);
+  const [newTagColor, setNewTagColor] = useState('');
+  const [reload, setReload] = useState(0);
+
+  //태그 선택 해제
+  const unSetTagItem = () => {
+    setTagObject(null);
+    setTagInput('');
+  };
 
   //TAG GET
   useEffect(() => {
     const fetchData = async () => {
       try {
         const result = await axios.get(`${HOST}/api/v1/tag`);
-        setTagList(result.data);
+        const list = result.data.sort((a: Tag, b: Tag) => b.count - a.count);
+        setTagList(list);
       } catch (error) {
         console.log(error);
       }
     };
     fetchData();
-  }, [, () => postNewTag]);
+  }, [reload]);
 
   //검색된 Tag
-  const filteredTagList = tagList.filter((itemList) => itemList.title.toUpperCase().includes(tagInput.toUpperCase()));
+  useEffect(() => {
+    setSearchedTagList(tagList.filter((itemList) => itemList.title.toUpperCase().includes(tagInput.toUpperCase())));
+  }, [tagList, tagInput]);
 
   //하나의 태그 선택
   const setTagItem = (e: React.MouseEvent<HTMLDivElement>) => {
-    setSelectedTag(filteredTagList.find((item) => item.idx.toString() === e.currentTarget!.dataset.idx));
-    setTagIdx(Number(e.currentTarget.dataset.idx));
-  };
-
-  //태그 선택 해제
-  const unSetTagItem = () => {
-    setSelectedTag(null);
-    setTagIdx(null);
-    setIsTagInputFocused(true);
-    setTagInput('');
+    setTagObject(searchedTagList.find((item) => item.idx.toString() === e.currentTarget!.dataset.idx) || null);
   };
 
   //POST TAG
@@ -56,58 +58,94 @@ const TagInput = ({ setTagIdx }: TagInputProps) => {
         title: tagInput,
         color: newTagColor,
       } as Tag;
-      const result = await axios.post(`${HOST}/api/v1/tag`, newTagData);
-
-      if (result.status === 200) {
-        setSelectedTag(newTagData); // 표시되는 데이터 갱신
-        setTagIdx(result.data.idx); // tagIdx(form에서 사용되는 값)를 추가된 Tag의 idx로 갱신
-      }
+      await axios.post(`${HOST}/api/v1/tag`, newTagData).then((res) => {
+        if (res.status === 200) {
+          setTagObject({ ...newTagData, idx: res.data.idx, count: 0 });
+          setReload(reload + 1);
+        }
+      });
     } catch (error) {
-      alert('Tag 생성에 실패했습니다.');
-      // 각 실패 처리에 대한 논의 후 에러 메시지 분기 추가하겠습니다.
-      console.log(error);
+      alert('이미 존재하는 태그입니다.');
+    }
+  };
+
+  //DELET TAG
+  const deleteTag = async (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    try {
+      await axios.delete(`${HOST}/api/v1/tag/${e.currentTarget!.dataset.idx}`).then((res) => {
+        if (res.status == 200) setReload(reload + 1);
+      });
+    } catch (error) {
+      alert('태그 삭제에 실패했습니다.');
+    }
+    setIsTagInputFocused(true);
+  };
+
+  const onChangeTagColor = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTagObject((prev) => {
+      return { ...prev, color: e.target.value } as Tag;
+    });
+  };
+
+  const postColorChange = async (e: React.FocusEvent<HTMLInputElement>) => {
+    try {
+      const r = await axios.post(`${HOST}/api/v1/tag/color/${tagObject!.idx}`, { color: tagObject!.color }).then((res) => {
+        if (res.status == 200) setReload(reload + 1);
+      });
+    } catch (error) {
+      alert('색상 변경에 실패했습니다.');
     }
   };
 
   useEffect(() => {
-    setNewTagColor(`#${Math.round(Math.random() * 0xffff).toString(16)}`);
-  }, []);
+    let color_r = Math.floor(Math.random() * 127 + 128).toString(16);
+    let color_g = Math.floor(Math.random() * 127 + 128).toString(16);
+    let color_b = Math.floor(Math.random() * 127 + 128).toString(16);
+    setNewTagColor(`#${color_r + color_g + color_b}`);
+  }, [reload]);
 
-  if (selectedTag === null || selectedTag == undefined)
-    // 태그 선택 전
+  const SearchedTagList = () => {
     return (
-      <TagContainer>
-        <InputBar onChange={onTagInputChange} onFocus={(e) => setIsTagInputFocused(true)} onBlur={(e) => setIsTagInputFocused(false)} />
-        {isTagInputFocused ? (
-          <TagList>
-            {filteredTagList.map((item) => {
-              return (
-                <TagListItem key={item.idx} data-idx={item.idx} onMouseDown={setTagItem}>
-                  <TagTitle color={item.color}>
-                    <a>{item.title}</a>
-                  </TagTitle>
-                </TagListItem>
-              );
-            })}
-            {tagInput != '' ? (
-              <TagListItem onMouseDown={postNewTag}>
-                <TagTitle color={newTagColor}>
-                  생성 : <a>{tagInput}</a>
-                </TagTitle>
-              </TagListItem>
-            ) : null}
-          </TagList>
-        ) : null}
-      </TagContainer>
+      <TagList>
+        {searchedTagList.map(({ idx, color, title, count }) => {
+          return (
+            <TagListItem key={idx} data-idx={idx} onMouseDown={setTagItem}>
+              <TagTitle color={color} create={false}>
+                <span>{title}</span>
+                {count === 0 && (
+                  <DelIcon data-idx={idx} onMouseDown={deleteTag}>
+                    삭제
+                  </DelIcon>
+                )}
+              </TagTitle>
+            </TagListItem>
+          );
+        })}
+        {tagInput !== '' && (
+          <TagListItem onMouseDown={postNewTag}>
+            <TagTitle color={newTagColor} create={true}>
+              {'생성 : '}
+              <span>{tagInput}</span>
+            </TagTitle>
+          </TagListItem>
+        )}
+      </TagList>
     );
+  };
 
-  // 하나의 태그가 선택되었을 때
-  return (
+  return tagObject === null ? (
+    <TagContainer>
+      <InputBar value={tagInput} onChange={onChangeTagInput} onFocus={(e) => setIsTagInputFocused(true)} onBlur={(e) => setIsTagInputFocused(false)} />
+      {isTagInputFocused && <SearchedTagList />}
+    </TagContainer>
+  ) : (
     <TagContainer>
       <Bar>
-        <SelectedTag color={selectedTag?.color}>
-          {selectedTag!.title} <CloseButton onClick={unSetTagItem} />
+        <SelectedTag color={tagObject?.color}>
+          {tagObject!.title} <CloseButton onClick={unSetTagItem} />
         </SelectedTag>
+        <ColorPicker type="color" value={tagObject.color} onChange={onChangeTagColor} onBlur={postColorChange} />
       </Bar>
     </TagContainer>
   );
@@ -139,21 +177,37 @@ const TagListItem = styled.div`
   }
 `;
 
-const TagTitle = styled.div`
-  display: table-cell;
-  vertical-align: middle;
+const TagTitle = styled.div<{ color: string; create: boolean }>`
+  display: flex;
   padding: 2.5px 3px 2.5px 5px;
-  a {
+  align-items: center;
+  height: 27px;
+  font-size: 0.8rem;
+  justify-content: ${(props) => (props.create ? 'baseline' : 'space-between')};
+
+  span {
+    cursor: pointer;
+    margin: 0px;
     display: inline-block;
     padding: 2px 6px 2px 6px;
-    background-color: ${(props) => props.color || 'black'};
+    background-color: ${(props) => props.color || 'white'};
     border-radius: 3px;
     height: 19px;
     line-height: 19px;
   }
-  font-size: 0.8rem;
 `;
 
+const DelIcon = styled.div`
+  text-align: right;
+  cursor: pointer;
+  color: var(--color-gray6);
+  margin: 0px;
+  font-size: 10px;
+  display: inline-block;
+  padding: 2px 6px 2px 6px;
+  height: 19px;
+  line-height: 19px;
+`;
 export const InputBar = styled.input`
   margin: auto;
   background: var(--color-gray0);
@@ -177,6 +231,7 @@ export const Bar = styled.div`
   padding-left: 0.6rem;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 `;
 
 const SelectedTag = styled.div`
@@ -184,7 +239,7 @@ const SelectedTag = styled.div`
   display: flex;
   line-height: 19px;
   height: 19px;
-  background-color: ${(props) => props.color || 'black'};
+  background-color: ${(props) => props.color || 'white'};
   border-radius: 3px;
   font-size: 0.8rem;
 `;
@@ -195,4 +250,22 @@ const CloseButton = styled(RiCloseLine)`
   margin: auto;
   padding: 3px;
   cursor: pointer;
+`;
+
+const ColorPicker = styled.input`
+  cursor: pointer;
+  border: 1px solid var(--color-gray3);
+  padding: 0px;
+  background-color: inherit;
+  width: 1.2rem;
+  height: 1.2rem;
+  margin: 0.8rem;
+  z-index: 999;
+
+  ::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  ::-webkit-color-swatch {
+    border: none;
+  }
 `;

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -3,13 +3,13 @@ import * as S from './TaskModal.style';
 import ImportanceInput from './ImportanceInput';
 import TagInput from './TagInput';
 import useInput from '../../hooks/useInput';
+import { Tag } from 'GlobalType';
 
 interface Props {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const TaskModal = (props: Props) => {
-  const [tagidx, setTagIdx] = useState<number | null>(null);
-  const [locationObject, setLocationObject] = useState<Location | null>(null); // { location, lng, lat }
+  const [tagObject, setTagObject] = useState<Tag | null>(null);
 
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
@@ -31,7 +31,7 @@ const TaskModal = (props: Props) => {
               <tr>
                 <td>태그</td>
                 <td>
-                  <TagInput setTagIdx={setTagIdx} />
+                  <TagInput tagObject={tagObject} setTagObject={setTagObject} />
                 </td>
               </tr>
               <tr>

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -35,6 +35,7 @@ declare module 'GlobalType' {
     idx: number;
     title: string;
     color: string;
+    count: number;
   }
 
   interface CompletionCheckBoxStatus {

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -28,8 +28,8 @@ router.post('/color/:tag_idx', authenticateToken, async (req: AuthorizedRequest,
   const tagIdx = req.params.tag_idx;
   const { color } = req.body;
   try {
-    const result = await executeSql('update tag set color = ? where idx = ? and user_idx = ?', [color, tagIdx, userIdx]);
-    res.status(200);
+    await executeSql('update tag set color = ? where idx = ? and user_idx = ?', [color, tagIdx, userIdx]);
+    res.sendStatus(200);
   } catch {
     res.sendStatus(403);
   }


### PR DESCRIPTION
## 요약
- **7-18.** [ 존재하는 태그를 삭제하거나 / 선택된 태그의 색상을 변경할 수 있다. - 구현
- tag 생성 **실패 메세지** 추가
- 그 외 tagInput 관련 **오류 다수 수정**
- 비슷한 로직인 LocationInput #66 피드백 사항을 반영하여 **리팩토링** 하였습니다.

## 작동 화면
- Log 화면의 (+) 버튼으로 접근하는 task 추가 모달 내 태그 인풋 컴포넌트
- 태그 조회 / 생성 / 선택 관련 로직은 #57 에 명시되어 있습니다.

### 색상 변경
![Nov-23-2022 16-06-58](https://user-images.githubusercontent.com/73420533/203489793-713bcd08-671d-4660-8e7a-b77c5a838cc5.gif)
- 하나의 tag를 선택하면 우측에 컬러 픽커가 표시된다.
  - 해당 컬러 픽커를 클릭하여 색깔을 변경할 수 있다.
  - 변경을 완료한 후 리스트에서 색깔이 변경되었음을 확인할 수 있다.
  
### 생성 실패 에러 메세지
![Nov-23-2022 16-07-23](https://user-images.githubusercontent.com/73420533/203490603-2fcc015a-b9a7-4871-b46e-d6931221abbb.gif)
- 중복된 이름의 task 생성 요청 시 실패 메세지가 표시된다.

### 삭제 
![Nov-23-2022 16-07-44](https://user-images.githubusercontent.com/73420533/203490768-362fe552-6509-47fd-8e69-4212b41ebb18.gif)
- tag 리스트를 조회할 때, task에서 사용하지 않고 있는 tag에 한해서 삭제 버튼이 나타난다.
- 해당 버튼을 클릭하여 tag를 삭제할 수 있다.

### 작업 내용
- TagInput 컴포넌트
  - TaskModal 컴포넌트에서 해당 컴포넌트 사용
  - TagInput에서 선택되는 태그를 tagObject로 TaskModal과 공통 관리하도록 변경했습니다.

## 비고
- 최초 tag 삭제 시 조회 창이 깜빡이는 이슈는 API 호출 문제가 아니라, FE 단의 focus 처리 관련 로직 때문입니다. 추후 여유가 있을 때 해결을 시도해보겠습니다.
