### PR TITLE
[BE] [4-16] 친구 요청 API 구현

### DIFF
--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -52,7 +52,7 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
 
-  if (userIdx.toString() === friendIdx) return res.status(404).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
+  if (userIdx.toString() === friendIdx) return res.status(409).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
 
   const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx.toString()])) as RowDataPacket).length === 0;
   if (notExistUser) return res.status(404).json({ msg: '존재하지 않는 사용자예요.' });
@@ -67,13 +67,13 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
 
     if (friendRequest.length === 0) {
       await executeSql('insert into friendship (sender_idx, receiver_idx, accepted) values (?, ?, false)', [userIdx.toString(), friendIdx.toString()]);
-      return res.sendStatus(200);
+      return res.sendStatus(201);
     }
 
     const { sender_idx: senderIdx, accepted } = friendRequest[0];
 
-    if (accepted) return res.status(404).json({ msg: '이미 친구예요.' });
-    if (senderIdx === userIdx) return res.status(404).json({ msg: '이미 친구 요청을 보냈어요.' });
+    if (accepted) return res.status(409).json({ msg: '이미 친구예요.' });
+    if (senderIdx === userIdx) return res.status(409).json({ msg: '이미 친구 요청을 보냈어요.' });
 
     await executeSql('update friendship set accepted = true where sender_idx = ? and receiver_idx = ?', [friendIdx.toString(), userIdx.toString()]);
     return res.status(200).json({ msg: '이미 나에게 친구 요청을 보낸 사용자예요. 자동으로 친구가 되었어요.' });

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -24,6 +25,24 @@ router.get('/request', authenticateToken, async (req: AuthorizedRequest, res) =>
   try {
     const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx.toString()]);
     res.json(users);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+router.delete('/:user_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const friendIdx = req.params.user_idx;
+  try {
+    const { affectedRows } = (await executeSql('delete from friendship where ((sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)) and accepted = true', [
+      userIdx.toString(),
+      friendIdx.toString(),
+      friendIdx.toString(),
+      userIdx.toString(),
+    ])) as RowDataPacket;
+
+    if (affectedRows === 0) return res.status(404).json({ msg: '존재하지 않는 친구예요.' });
+    res.sendStatus(200);
   } catch {
     res.sendStatus(500);
   }

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -51,6 +51,10 @@ router.delete('/:user_idx', authenticateToken, async (req: AuthorizedRequest, re
 router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
+
+  const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx.toString()])) as RowDataPacket).length === 0;
+  if (notExistUser) return res.status(404).json({ msg: '존재하지 않는 사용자예요.' });
+
   try {
     const friendRequest = (await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [
       userIdx.toString(),

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -69,7 +69,7 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
     if (accepted) return res.status(404).json({ msg: '이미 친구예요.' });
     if (senderIdx === userIdx) return res.status(404).json({ msg: '이미 친구 요청을 보냈어요.' });
 
-    await executeSql('update friendship set accepted = true where sender_idx = ? and receiver_idx = ?;', [friendIdx.toString(), userIdx.toString()]);
+    await executeSql('update friendship set accepted = true where sender_idx = ? and receiver_idx = ?', [friendIdx.toString(), userIdx.toString()]);
     return res.status(200).json({ msg: '이미 나에게 친구 요청을 보낸 사용자예요. 자동으로 친구가 되었어요.' });
   } catch {
     res.sendStatus(500);

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -52,6 +52,8 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
 
+  if (userIdx.toString() === friendIdx) return res.status(404).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
+
   const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx.toString()])) as RowDataPacket).length === 0;
   if (notExistUser) return res.status(404).json({ msg: '존재하지 않는 사용자예요.' });
 


### PR DESCRIPTION
## 요약
친구 요청을 전송하는 API를 구현하였습니다.
- 요청 URL : `/friend/request/:user_idx`
   - `user_idx` : 친구 요청을 보내고 싶은 사용자
- 응답
   - 친구 요청 성공 : `201`
   - 이미 나에게 친구 요청을 보냈던 사용자에게 친구 요청을 보낼 경우 자동으로 친구가 됨 : `200`
   - 친구 요청을 이미 보냈거나 이미 친구인 경우 : `409`
   - 존재하지 않는 사용자에 대한 친구 요청 : `404`
   - 스스로에 대한 친구 요청 : `409`
   - DB 및 서버에 문제 발생 : `500`

## 작업 내용
1. 친구 요청 전송 API 구현
현재 친구 관계에 대한 테이블 `friendship`의 정보는 아래와 같습니다.
   - `sender_idx` = 친구 요청 전송자
   - `receiver_idx` = 친구 요청 수신자
   - `accepted` = 친구 요청 승인 여부 (true이면 친구 관계, false이면 친구 요청 대기 상태)
   <br>

   ```
   +--------------+------------+------+-----+---------+-------+
   | Field        | Type       | Null | Key | Default | Extra |
   +--------------+------------+------+-----+---------+-------+
   | sender_idx   | int(11)    | YES  | MUL | NULL    |       |
   | receiver_idx | int(11)    | YES  | MUL | NULL    |       |
   | accepted     | tinyint(1) | YES  |     | NULL    |       |
   +--------------+------------+------+-----+---------+-------+
   ```
   이 때 친구 요청을 전송하는 경우 아래의 네 가지 상황이 존재하고 각 상황에 대한 처리 방법과 응답은 다음과 같습니다.
   1. 이미 친구인 경우 → `404`
   4. 이미 친구 요청을 보낸 경우 (친구 요청 대기 상태인 경우) → `404`
   5. 상대에게서 친구 요청을 받았는데 상대에게 친구 요청을 보내는 경우 → 상대에게서 받은 친구 요청을 자동으로 승인하여 친구 관계가 되도록 함, `200`
   6. 아무런 관계가 없는 상태에서 친구 요청을 보내는 경우 → 친구 요청 전송, `200`

   `friendship` 테이블로 친구 요청 대기 상태와 친구 관계를 모두 관리하므로 API 요청 시 해당 테이블에 대한 쿼리를 통해 현재 상황이 위의 네 가지 상황 중 어떤 상황에 속하는지 검사하고 각 상황에 맞는 동작을 처리해줍니다.

## 작동 화면
### 이미 친구인 사용자에게 친구 요청
1. `/friend`를 통해 `user_idx = 14` 사용자와 친구임을 확인
2. `user_idx = 14` 사용자에게 친구 요청
3. `404` 코드 확인

[85c16904-850c-4196-9547-3697d5dfadd9.webm](https://user-images.githubusercontent.com/92143119/203607469-3de73125-41dc-403c-a00b-6d8701b7983d.webm)

### 나에게 친구 요청을 보낸 사용자에게 친구 요청
1. `/friend/request`를 통해 `user_idx = 12` 사용자가 나에게 친구 요청을 보냈음을 확인
2. `user_idx = 12` 사용자에게 친구 요청
3. `/friend`를 통해 `user_idx = 12` 사용자와 자동으로 친구가 되었음을 확인

[73ecab79-7195-4edd-b608-38eea4228b18.webm](https://user-images.githubusercontent.com/92143119/203607483-1774daed-d4e8-4d38-b660-f6cbab852f6a.webm)

### 친구 요청 전송
좌측 : `user_idx = 19`
우측 : `user_idx = 29`
1. 우측 (`user_idx = 29`) : `friend/request`를 통해 수신된 친구 요청이 없음을 확인
2. 좌측 (`user_idx = 19`) : `user_idx = 29` 사용자에게  친구 요청
3. 우측 (`user_idx = 29`) : `friend/request`를 통해 `user_idx = 19`의 친구 요청이 수신되었음을 확인
4. 좌측 (`user_idx = 19`) : `user_idx = 29` 사용자에게 친구 요청을 또 보내자 `404` 코드가 응답되는 것을 확인

[8f7566f3-61be-49b5-bfb4-ef8316562c95.webm](https://user-images.githubusercontent.com/92143119/203607497-76f06d69-b937-4b46-80c7-07422ee2ec6f.webm)


## 테스트 방법
1. 로그인을 완료합니다.
5. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/friend/request/${user_idx}', {
     method: 'put',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     }
   });
   ```
## 관련 Task
- 4-16

## 비고
친구 삭제 API를 구현한 PR이 merge 되지 않아 해당 PR에 친구 삭제 API에 관한 커밋이 함께 들어가게 되었습니다.
친구 요청 API에 관한 부분만 봐주시면 될 것 같습니다.
파일의 51 라인~끝 부분을 봐주시면 됩니다.