### PR TITLE
[BE] [7-26] 태스크 이모티콘 조회 API 구현

### DIFF
--- a/server/src/api/emoticon.ts
+++ b/server/src/api/emoticon.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/task/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const taskIdx = req.params.task_idx;
+  try {
+    const notExistTask = ((await executeSql('select idx from task where idx = ? and user_idx = ?', [taskIdx.toString(), userIdx.toString()])) as RowDataPacket).length === 0;
+    if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 태스크예요.' });
+
+    const emoticons = await executeSql(
+      'select task_social_action.idx, emoticon.value as emoticon, user.user_id as author_name from task_social_action inner join emoticon on task_social_action.emoticon_idx = emoticon.idx inner join user on task_social_action.author_idx = user.idx where task_idx = ?',
+      [taskIdx.toString()]
+    );
+    res.json(emoticons);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/server/src/api/emoticon.ts
+++ b/server/src/api/emoticon.ts
@@ -11,7 +11,7 @@ router.get('/task/:task_idx', authenticateToken, async (req: AuthorizedRequest, 
   const taskIdx = req.params.task_idx;
   try {
     const notExistTask = ((await executeSql('select idx from task where idx = ? and user_idx = ?', [taskIdx.toString(), userIdx.toString()])) as RowDataPacket).length === 0;
-    if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 태스크예요.' });
+    if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 일정이에요.' });
 
     const emoticons = await executeSql(
       'select task_social_action.idx, emoticon.value as emoticon, user.user_id as author_name from task_social_action inner join emoticon on task_social_action.emoticon_idx = emoticon.idx inner join user on task_social_action.author_idx = user.idx where task_idx = ?',

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -5,6 +5,7 @@ import labelRouter from './label';
 import tagRouter from './tag';
 import userRouter from './user';
 import friendRouter from './friend';
+import emoticonRouter from './emoticon';
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.use('/label', labelRouter);
 router.use('/tag', tagRouter);
 router.use('/user', userRouter);
 router.use('/friend', friendRouter);
+router.use('/emoticon', emoticonRouter);
 
 export default router;


### PR DESCRIPTION
## 요약
다른 사용자가 나의 태스크에 남긴 이모티콘의 목록을 조회할 수 있는 API를 구현하였습니다.
- 요청 URL : `/emoticon/task/:task_idx`
   - `task_idx` : 조회하고 싶은 태스크
   - method : `GET`
- 응답
   - `[{idx, emoticon, author_name}]` (이모티콘 정보 객체 배열)
   - 존재하지 않는 태스크에 대한 실행 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 존재하지 않는 태스크의 이모티콘 목록 조회
1. `/task`를 통해 현재 태스크의 목록을 조회
2. `/emoticon/task/10`를 통해 현재 존재하지 않는 `idx = 10` 태스크에 대한 이모티콘 목록 조회 요청
3. 존재하지 않는 태스크라는 메시지가 반환됨을 확인

[fff7cdc4-1069-4d40-9f0d-07a109a5a476.webm](https://user-images.githubusercontent.com/92143119/204086810-15971251-7f23-4ff1-add2-59649af09070.webm)
### 태스크의 이모티콘 목록 조회
1. `/task`를 통해 현재 태스크의 목록을 조회
2. `/emoticon/task/14`를 통해 현재 존재하는 `idx = 14` 태스크에 대한 이모티콘 목록 조회 요청
3. 정상적으로 이모티콘 목록이 반환됨을 확인

[896dcc3b-2ff9-41da-b9c9-7adbbf5fb0a1.webm](https://user-images.githubusercontent.com/92143119/204086883-321ef39a-c64c-49ba-a370-a85c68f579aa.webm)


## 작업 내용
1. emoticon API route 설정
2. 태스크의 이모티콘 목록 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. `/task`를 통해 현재 사용자의 태스크 목록을 확인합니다.
3. 주소창에 `http://localhost:8000/api/v1/emoticon/task/${task_idx}`를 입력합니다.

## 관련 Task
- [7-26]