### PR TITLE
[BE] [15] task 날짜별로 조회하도록 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -8,7 +8,9 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const rows = await executeSql('select * from task where user_idx = ?', [userIdx.toString()]);
+  const { date } = req.query;
+  if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
+  const rows = await executeSql('select * from task where user_idx = ? and date = ?', [userIdx.toString(), date.toString()]);
   res.json(rows);
 });
 


### PR DESCRIPTION
## 요약
task 조회 API 호출 시 URL query string에 date를 포함시켜야 동작하도록 수정하였습니다.
## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/204091376-b6515873-d221-4ad7-9be4-d7df103e113b.png)


## 테스트 방법
1. 로그인을 완료하세요.
2. 주소창에 `http://localhost:8000/api/v1/task?date=2022-11-22`을 입력하세요.
