### PR TITLE
[BE] [18] task 생성 요청 시 body에 필수 요소만 넣어도 동작하도록 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -73,7 +73,10 @@ const validate = (key, value) => {
     case TaskBodyKeys.startedAt:
     case TaskBodyKeys.endedAt: {
       const regex = /^([01][0-9]|2[0-3]):([0-5][0-9])$/;
-      return regex.test(value);
+      if (!regex.test(value)) {
+        throw new ValidationError();
+      }
+      return true;
     }
     case TaskBodyKeys.tagIdx: {
       return typeof value === 'number';


### PR DESCRIPTION
## 요약
task 생성 요청의 body에 일부 요소가 누락되어 있는 경우 해당 요소가 필수가 아님에도 서버가 죽는 에러를 수정하였습니다.
## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/204091754-97cea5b0-a2c6-4e09-937b-db746fe5f47a.png)

## 테스트 방법
1. 로그인을 완료하세요.
2. 개발자 도구를 열고 다음 코드를 입력하세요.
```
fetch('http://localhost:8000/api/v1/task', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({
    title: '낮잠',
    date: '2022-11-22',
  }),
}).then((res) => {
  if (res.ok) console.log('GOOD');
});
```
3. 콘솔에 `GOOD`이 출력되는지 확인하세요.
