### PR TITLE
[BE] [24] 라벨 조회 API 수정

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -7,7 +7,9 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const labels = await executeSql('select idx, title, color, unit from label where user_idx = ?', [userIdx.toString()]);
+  const labels = await executeSql('select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) as count from label left join task_label on label.idx = task_label.label_idx where label.user_idx = ? group by label.idx', [
+    userIdx.toString(),
+  ]);
   res.json(labels);
 });
 

--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -7,10 +7,14 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const labels = await executeSql('select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) as count from label left join task_label on label.idx = task_label.label_idx where label.user_idx = ? group by label.idx', [
-    userIdx.toString(),
-  ]);
-  res.json(labels);
+  try {
+    const labels = await executeSql('select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) as count from label left join task_label on label.idx = task_label.label_idx where label.user_idx = ? group by label.idx', [
+      userIdx.toString(),
+    ]);
+    res.json(labels);
+  } catch {
+    res.sendStatus(500);
+  }
 });
 
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {


### PR DESCRIPTION
## 요약
라벨 조회 시 count(라벨 사용 횟수)를 함께 반환하도록 API를 수정하였습니다.
- 요청 URL : `/label`
   - method : `GET`
- 응답
   - `[{ idx, title, color, unit, count }]` (라벨 객체 배열)
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/label`을 통해 라벨의 목록이 반환됨을 확인

[328eca62-41ad-4dac-8e08-cb9de5a64342.webm](https://user-images.githubusercontent.com/92143119/204204135-14f7bf93-86e7-4507-9fa6-fee12c13c89c.webm)

## 작업 내용
1. 라벨 조회 시 count(라벨 사용 횟수)를 반환하도록 수정
2. `try catch` 문을 사용하여 서버에서 에러 발생시 `500` 코드를 반환하도록 수정

## 테스트 방법
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/label`를 입력합니다.

## 관련 Task
- [24]