### PR TITLE
[BE] [26] executeSql 함수의 values 타입 변경

### DIFF
--- a/server/src/api/emoticon.ts
+++ b/server/src/api/emoticon.ts
@@ -10,12 +10,12 @@ router.get('/task/:task_idx', authenticateToken, async (req: AuthorizedRequest, 
   const { userIdx } = req.user;
   const taskIdx = req.params.task_idx;
   try {
-    const notExistTask = ((await executeSql('select idx from task where idx = ? and user_idx = ?', [taskIdx.toString(), userIdx.toString()])) as RowDataPacket).length === 0;
+    const notExistTask = ((await executeSql('select idx from task where idx = ? and user_idx = ?', [taskIdx, userIdx])) as RowDataPacket).length === 0;
     if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 일정이에요.' });
 
     const emoticons = await executeSql(
       'select task_social_action.idx, emoticon.value as emoticon, user.user_id as author_name from task_social_action inner join emoticon on task_social_action.emoticon_idx = emoticon.idx inner join user on task_social_action.author_idx = user.idx where task_idx = ?',
-      [taskIdx.toString()]
+      [taskIdx]
     );
     res.json(emoticons);
   } catch {
@@ -33,10 +33,10 @@ router.put('/task/:task_idx', authenticateToken, async (req: PutEmoticonRequest,
     const notExistTask = ((await executeSql('select idx from task where idx = ?', [taskIdx])) as RowDataPacket).length === 0;
     if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 일정이에요.' });
 
-    const notExistEmoticon = ((await executeSql('select idx from emoticon where idx = ?', [emoticon.toString()])) as RowDataPacket).length === 0;
+    const notExistEmoticon = ((await executeSql('select idx from emoticon where idx = ?', [emoticon])) as RowDataPacket).length === 0;
     if (notExistEmoticon) return res.status(404).json({ msg: '존재하지 않는 이모티콘이에요.' });
 
-    await executeSql('insert into task_social_action (task_idx, emoticon_idx, author_idx) values (?, ?, ?);', [taskIdx, emoticon.toString(), userIdx.toString()]);
+    await executeSql('insert into task_social_action (task_idx, emoticon_idx, author_idx) values (?, ?, ?);', [taskIdx, emoticon, userIdx]);
     res.sendStatus(201);
   } catch {
     res.sendStatus(500);

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -47,7 +47,7 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
 
-  if (userIdx.toString() === friendIdx) return res.status(409).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
+  if (userIdx === parseInt(friendIdx)) return res.status(409).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
 
   const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx])) as RowDataPacket).length === 0;
   if (notExistUser) return res.status(404).json({ msg: '존재하지 않는 사용자예요.' });

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -10,9 +10,9 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
     const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true', [
-      userIdx.toString(),
-      userIdx.toString(),
-      userIdx.toString(),
+      userIdx,
+      userIdx,
+      userIdx,
     ]);
     res.json(users);
   } catch {
@@ -23,7 +23,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.get('/request', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx.toString()]);
+    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx]);
     res.json(users);
   } catch {
     res.sendStatus(500);
@@ -34,12 +34,7 @@ router.delete('/:user_idx', authenticateToken, async (req: AuthorizedRequest, re
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
   try {
-    const { affectedRows } = (await executeSql('delete from friendship where ((sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)) and accepted = true', [
-      userIdx.toString(),
-      friendIdx.toString(),
-      friendIdx.toString(),
-      userIdx.toString(),
-    ])) as RowDataPacket;
+    const { affectedRows } = (await executeSql('delete from friendship where ((sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)) and accepted = true', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket;
 
     if (affectedRows === 0) return res.status(404).json({ msg: '존재하지 않는 친구예요.' });
     res.sendStatus(200);
@@ -54,19 +49,14 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
 
   if (userIdx.toString() === friendIdx) return res.status(409).json({ msg: '스스로에게 친구 요청을 할 수 없어요.' });
 
-  const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx.toString()])) as RowDataPacket).length === 0;
+  const notExistUser = ((await executeSql('select idx from user where idx = ?', [friendIdx])) as RowDataPacket).length === 0;
   if (notExistUser) return res.status(404).json({ msg: '존재하지 않는 사용자예요.' });
 
   try {
-    const friendRequest = (await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [
-      userIdx.toString(),
-      friendIdx.toString(),
-      friendIdx.toString(),
-      userIdx.toString(),
-    ])) as RowDataPacket;
+    const friendRequest = (await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket;
 
     if (friendRequest.length === 0) {
-      await executeSql('insert into friendship (sender_idx, receiver_idx, accepted) values (?, ?, false)', [userIdx.toString(), friendIdx.toString()]);
+      await executeSql('insert into friendship (sender_idx, receiver_idx, accepted) values (?, ?, false)', [userIdx, friendIdx]);
       return res.sendStatus(201);
     }
 
@@ -75,7 +65,7 @@ router.put('/request/:user_idx', authenticateToken, async (req: AuthorizedReques
     if (accepted) return res.status(409).json({ msg: '이미 친구예요.' });
     if (senderIdx === userIdx) return res.status(409).json({ msg: '이미 친구 요청을 보냈어요.' });
 
-    await executeSql('update friendship set accepted = true where sender_idx = ? and receiver_idx = ?', [friendIdx.toString(), userIdx.toString()]);
+    await executeSql('update friendship set accepted = true where sender_idx = ? and receiver_idx = ?', [friendIdx, userIdx]);
     return res.status(200).json({ msg: '이미 나에게 친구 요청을 보낸 사용자예요. 자동으로 친구가 되었어요.' });
   } catch {
     res.sendStatus(500);
@@ -86,7 +76,7 @@ router.patch('/accept/:user_idx', authenticateToken, async (req: AuthorizedReque
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
   try {
-    const { affectedRows } = (await executeSql('update friendship set accepted = true where receiver_idx = ? and sender_idx = ? and accepted = false', [userIdx.toString(), friendIdx.toString()])) as RowDataPacket;
+    const { affectedRows } = (await executeSql('update friendship set accepted = true where receiver_idx = ? and sender_idx = ? and accepted = false', [userIdx, friendIdx])) as RowDataPacket;
     if (affectedRows === 0) return res.status(404).json({ msg: '존재하지 않는 친구 요청이에요.' });
     res.sendStatus(200);
   } catch {
@@ -98,7 +88,7 @@ router.delete('/accept/:user_idx', authenticateToken, async (req: AuthorizedRequ
   const { userIdx } = req.user;
   const friendIdx = req.params.user_idx;
   try {
-    const { affectedRows } = (await executeSql('delete from friendship where receiver_idx = ? and sender_idx = ? and accepted = false', [userIdx.toString(), friendIdx.toString()])) as RowDataPacket;
+    const { affectedRows } = (await executeSql('delete from friendship where receiver_idx = ? and sender_idx = ? and accepted = false', [userIdx, friendIdx])) as RowDataPacket;
     if (affectedRows === 0) return res.status(404).json({ msg: '존재하지 않는 친구 요청이에요.' });
     res.sendStatus(200);
   } catch {

--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const labels = await executeSql('select idx, title, color, unit from label where user_idx = ?', [userIdx.toString()]);
+  const labels = await executeSql('select idx, title, color, unit from label where user_idx = ?', [userIdx]);
   res.json(labels);
 });
 

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
-  const tags = await executeSql('select tag.idx as idx, tag.title as title, tag.color as color, count(task.idx) as count from tag left join task on task.tag_idx = tag.idx where tag.user_idx = ? group by tag.idx', [userIdx.toString()]);
+  const tags = await executeSql('select tag.idx as idx, tag.title as title, tag.color as color, count(task.idx) as count from tag left join task on task.tag_idx = tag.idx where tag.user_idx = ? group by tag.idx', [userIdx]);
   res.json(tags);
 });
 
@@ -40,7 +40,7 @@ router.delete('/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res
   const tagIdx = req.params.tag_idx;
 
   try {
-    await executeSql('delete from tag where user_idx = ? and idx = ?', [userIdx.toString(), tagIdx]);
+    await executeSql('delete from tag where user_idx = ? and idx = ?', [userIdx, tagIdx]);
     res.sendStatus(200);
   } catch (error) {
     res.sendStatus(403);

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { OkPacket } from 'mysql2';
+import { OkPacket, RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -58,6 +58,27 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
     res.sendStatus(200);
   } catch (error) {
     res.sendStatus(400);
+  }
+});
+
+router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const taskIdx = req.params.task_idx;
+  const { done } = req.body;
+
+  if (!(Object.keys(req.body).length === 1 && typeof done === 'boolean')) return res.sendStatus(400);
+
+  try {
+    const [task] = (await executeSql('select user_idx, done from task where idx = ?', [taskIdx])) as RowDataPacket[];
+
+    if (!task) return res.sendStatus(404);
+    if (task.user_idx !== userIdx) return res.sendStatus(403);
+    if (task.done === done) return res.sendStatus(409);
+
+    await executeSql('update task set done = ? where idx = ?', [done, taskIdx]);
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(500);
   }
 });
 

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -10,7 +10,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { date } = req.query;
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
-  const rows = await executeSql('select * from task where user_idx = ? and date = ?', [userIdx.toString(), date.toString()]);
+  const rows = await executeSql('select * from task where user_idx = ? and date = ?', [userIdx, date]);
   res.json(rows);
 });
 

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -10,7 +10,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const userId = `%${req.query.user_id}%`;
   try {
-    const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx.toString()]);
+    const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx]);
     res.json(users);
   } catch {
     res.sendStatus(500);
@@ -20,7 +20,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.get('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const [userInfo] = (await executeSql('select user_id, username, profile_img from user where idx = ?', [userIdx.toString()])) as RowDataPacket[];
+    const [userInfo] = (await executeSql('select user_id, username, profile_img from user where idx = ?', [userIdx])) as RowDataPacket[];
     res.json(userInfo);
   } catch {
     res.sendStatus(500);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -9,7 +9,7 @@ const pool = mysql.createPool({
   waitForConnections: true,
 });
 
-const executeSql = async (sql: string, values?: string[]) => {
+const executeSql = async (sql: string, values?: any[]) => {
   try {
     const [rows] = await pool.execute(sql, values);
     return rows;


### PR DESCRIPTION
## 요약
- `executeSql` 함수의 `values` 타입을 `string[]`에서 `any[]`로 변경하였습니다.
   - SQL 문의 조건 등에 들어갈 값을 `values`에 배열의 형태로 전송하여 SQL 문을 실행하였는데
      SQL 문의 특성 상 `values` 배열에는 `number`, `string` 등 다양한 타입의 값이 들어갈 수 있습니다.
   - 따라서 타입을 지정하기 애매한 탓에 기존에는 `values`의 타입을 `string[]`으로 지정한 뒤
      `values`에 담을 값을 `string`으로 변경해주는 작업을 수행하였으나
      이는 불필요한 작업으로 여겨지며 `values` 배열에는 여러 타입의 값이 담기는 것이 정상적인 동작이므로
      `values`의 타입을 `any[]`로 변경하기로 결정하였습니다.
- `values`에 담을 값을 `string`으로 변경하는 코드를 삭제하였습니다.

## 작업 내용
1. `executeSql`의 `values` 타입 변경
2. `executeSql` 사용 시 `values`에 담을 값을 `string`으로 변경하는 코드 삭제
3. `idx` 값 비교 시 숫자의 형태로 비교하도록 수정

## 관련 Task
- [26]