### PR TITLE
[BE] [26] API Response의 key 값을 camelCase 형태로 수정

### DIFF
--- a/server/src/api/emoticon.ts
+++ b/server/src/api/emoticon.ts
@@ -14,7 +14,7 @@ router.get('/task/:task_idx', authenticateToken, async (req: AuthorizedRequest, 
     if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 일정이에요.' });
 
     const emoticons = await executeSql(
-      'select task_social_action.idx, emoticon.value as emoticon, user.user_id as author_name from task_social_action inner join emoticon on task_social_action.emoticon_idx = emoticon.idx inner join user on task_social_action.author_idx = user.idx where task_idx = ?',
+      'select task_social_action.idx, emoticon.value as emoticon, user.user_id as authorName from task_social_action inner join emoticon on task_social_action.emoticon_idx = emoticon.idx inner join user on task_social_action.author_idx = user.idx where task_idx = ?',
       [taskIdx]
     );
     res.json(emoticons);

--- a/server/src/api/friend.ts
+++ b/server/src/api/friend.ts
@@ -9,11 +9,10 @@ const router = Router();
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true', [
-      userIdx,
-      userIdx,
-      userIdx,
-    ]);
+    const users = await executeSql(
+      'select idx, user_id as userId, username, profile_img as profileImg from user inner join friendship on idx = sender_idx or idx = receiver_idx where idx != ? and (receiver_idx = ? or sender_idx = ?) and accepted = true',
+      [userIdx, userIdx, userIdx]
+    );
     res.json(users);
   } catch {
     res.sendStatus(500);
@@ -23,7 +22,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.get('/request', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const users = await executeSql('select idx, user_id, username, profile_img from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx]);
+    const users = await executeSql('select idx, user_id as userId, username, profile_img as profileImg from user inner join friendship on idx = sender_idx where receiver_idx = ? and accepted = false', [userIdx]);
     res.json(users);
   } catch {
     res.sendStatus(500);

--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -10,7 +10,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const userId = `%${req.query.user_id}%`;
   try {
-    const users = await executeSql('select idx, user_id, username, profile_img from user where user_id LIKE ? and idx != ?', [userId, userIdx]);
+    const users = await executeSql('select idx, user_id as userId, username, profile_img as profileImg from user where user_id LIKE ? and idx != ?', [userId, userIdx]);
     res.json(users);
   } catch {
     res.sendStatus(500);
@@ -20,7 +20,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.get('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const [userInfo] = (await executeSql('select user_id, username, profile_img from user where idx = ?', [userIdx])) as RowDataPacket[];
+    const [userInfo] = (await executeSql('select user_id as userId, username, profile_img as profileImg from user where idx = ?', [userIdx])) as RowDataPacket[];
     res.json(userInfo);
   } catch {
     res.sendStatus(500);


### PR DESCRIPTION
## 요약
API Response의 key 값을 camelCase 형태로 수정하였습니다.
- 변경된 Response key
   - 태스크 이모티콘 조회 API
      - `author_name` → `authorName`
   - 친구 목록 조회 API, 친구 요청 목록 조회 API, 사용자 검색 API, 내 정보 조회 API
      - `user_id` → `userId`
      - `profile_img` → `profileImg`

## 작업 내용
1. API Response의 key 값 camelCase 형태로 수정

## 관련 Task
- [26]

## 비고
**앞으로 API 작업 시 `user_id` 등 snake_case 형태의 컬럼 값이 응답에 포함될 경우에는 `select user_id as userId from user`와 같은 형태로 SQL 문을 작성하셔서 Response에 camelCase 형태의 key 값이 포함되도록 작업해주시면 될 것 같습니다.**