### PR TITLE
[BE] [25] 태그 삭제 API 수정

### DIFF
--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { OkPacket } from 'mysql2';
+import { OkPacket, RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -40,10 +40,16 @@ router.delete('/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res
   const tagIdx = req.params.tag_idx;
 
   try {
+    const notExistTag = ((await executeSql('select idx from tag where user_idx = ? and idx = ?', [userIdx, tagIdx])) as RowDataPacket).length === 0;
+    if (notExistTag) return res.status(404).json({ msg: '존재하지 않는 태그예요.' });
+
+    const tagUsageCount = ((await executeSql('select idx from task where tag_idx = ?', [tagIdx])) as RowDataPacket).length;
+    if (tagUsageCount > 0) return res.status(404).json({ msg: '사용 중인 태그는 삭제할 수 없어요.' });
+
     await executeSql('delete from tag where user_idx = ? and idx = ?', [userIdx, tagIdx]);
     res.sendStatus(200);
   } catch (error) {
-    res.sendStatus(403);
+    res.sendStatus(500);
   }
 });
 

--- a/server/src/api/tag.ts
+++ b/server/src/api/tag.ts
@@ -44,7 +44,7 @@ router.delete('/:tag_idx', authenticateToken, async (req: AuthorizedRequest, res
     if (notExistTag) return res.status(404).json({ msg: '존재하지 않는 태그예요.' });
 
     const tagUsageCount = ((await executeSql('select idx from task where tag_idx = ?', [tagIdx])) as RowDataPacket).length;
-    if (tagUsageCount > 0) return res.status(404).json({ msg: '사용 중인 태그는 삭제할 수 없어요.' });
+    if (tagUsageCount > 0) return res.status(409).json({ msg: '사용 중인 태그는 삭제할 수 없어요.' });
 
     await executeSql('delete from tag where user_idx = ? and idx = ?', [userIdx, tagIdx]);
     res.sendStatus(200);


### PR DESCRIPTION
## 요약
태그를 삭제하기 전에 태그 존재 여부, 사용 여부를 검사하고 태그가 사용되지 않은 경우에만 태그를 삭제하도록 수정하였습니다.
- 요청 URL : `/tag/:tag_idx`
   - `tag_idx` : 삭제하고 싶은 태그
   - method : `DELETE`
- 응답
   - 태그 삭제 성공 : `200`
   - 존재하지 않는 태그 : `404`
   - 사용 중인 태그에 대한 요청 : `409`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 사용 중인 태그에 대한 요청
1. `/task?date=2022-12-01`을 통해 `idx = 3039` 태그가 사용 중임을 확인
2. 사용 중인 `idx = 3039` 태그에 대한 삭제 요청
3. `409` 코드가 반환됨을 확인

[fdab53ea-1463-4cc6-8392-c9df1798f288.webm](https://user-images.githubusercontent.com/92143119/204436295-8486de1a-d261-4971-827b-5b298bc4db66.webm)
### 존재하지 않는 태그에 대한 요청, 태그 삭제 성공
1. `/tag`를 통해 태그 목록 확인
2. 존재하지 않는 `idx = 30424` 태그에 대한 삭제 요청
3. `404` 코드가 반환됨을 확인
4. 사용 중이지 않은 `idx = 3042` 태그에 대한 삭제 요청
5. `/tag`를 통해 태그가 정상적으로 삭제된 것을 확인

[f9bb03fc-476b-4959-9d22-e69080ce78d4.webm](https://user-images.githubusercontent.com/92143119/204339879-b4c6c681-0061-4578-92b0-3e0644830731.webm)


## 작업 내용
1. 태그 삭제 전 태그 존재 여부를 검사하도록 수정
2. 태그 삭제 전 태그 사용 여부를 검사하여 해당 태그를 사용 중이지 않을 때만 삭제하도록 수정

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/tag/${tag_idx}', {
     method: 'delete',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
   });
   ```

## 관련 Task
- [25]