### PR TITLE
[BE] [7-28] 라벨 삭제 API 구현

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -22,6 +23,24 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { title, color, unit } = req.body;
   await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx]);
   res.sendStatus(200);
+});
+
+router.delete('/:label_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const labelIdx = req.params.label_idx;
+
+  try {
+    const notExistLabel = ((await executeSql('select idx from label where user_idx = ? and idx = ?', [userIdx, labelIdx])) as RowDataPacket).length === 0;
+    if (notExistLabel) return res.status(404).json({ msg: '존재하지 않는 라벨이에요.' });
+
+    const { labelUsageCount } = ((await executeSql('select count(ifnull(label_idx, 0)) as labelUsageCount from task_label where label_idx = ?', [labelIdx])) as RowDataPacket)[0];
+    if (labelUsageCount > 0) return res.status(409).json({ msg: '사용 중인 라벨은 삭제할 수 없어요.' });
+
+    await executeSql('delete from label where user_idx = ? and idx = ?', [userIdx, labelIdx]);
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(500);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## 요약
라벨을 삭제하는 API를 구현하였습니다.
- 요청 URL : `/label/:label_idx`
   - `label_idx` : 삭제하고 싶은 라벨
   - method : `DELETE`
- 응답
   - 라벨 삭제 성공 : `200`
   - 존재하지 않는 라벨 : `404`
   - 사용 중인 라벨에 대한 요청 : `409`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 사용 중인 라벨에 대한 요청
1. 사용 중인 `idx = 11` 라벨에 대한 삭제 요청
3. `409` 코드가 반환됨을 확인

[fe9646ea-e4ce-4960-ac2f-e2c8f7572df5.webm](https://user-images.githubusercontent.com/92143119/204444956-907c52ce-7519-4eb6-8777-caebb6031de2.webm)
### 존재하지 않는 라벨에 대한 요청, 라벨 삭제 성공
1. `/label`를 통해 라벨 목록 확인
2. 존재하지 않는 `idx = 15` 라벨에 대한 삭제 요청
3. `404` 코드가 반환됨을 확인
4. 사용 중이지 않은 `idx = 10` 라벨에 대한 삭제 요청
5. `/label`를 통해 라벨이 정상적으로 삭제된 것을 확인

[88dae6ca-a841-43fb-8928-c3325f3a50fd.webm](https://user-images.githubusercontent.com/92143119/204445065-cc33232e-857a-4025-aa00-54971afd8ffc.webm)

## 작업 내용
1. 라벨 삭제 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/label/${label_idx}', {
     method: 'delete',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
   });
   ```

## 관련 Task
- [7-28]