### PR TITLE
[FE/BE] [29] API 필드 이름 통일

### DIFF
--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -34,11 +34,7 @@ const Log = () => {
     const date = currentDate.toLocaleDateString().split('. ').join('-').substring(0, 10);
     const response = await axios.get(`${HOST}/api/v1/task?date=${date}`);
     const taskList = response.data;
-    return taskList.map((task: any) => {
-      const { content, date, done, ended_at, idx, importance, lat, lng, started_at, tag_idx, title, user_idx } = task;
-      const isPublic = task.public; // <- 구조 분해 할당 방해하는 주범
-      return { content, date, done, endedAt: ended_at, idx, importance, lat, lng, startedAt: started_at, tagIdx: tag_idx, title, userIdx: user_idx, isPublic };
-    });
+    return taskList;
   };
 
   useEffect(() => {

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -10,7 +10,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { date } = req.query;
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
-  const rows = await executeSql('select * from task where user_idx = ? and date = ?', [userIdx, date]);
+  const rows = await executeSql('select content, done, ended_at as endedAt, idx, importance, lat, lng, started_at as startedAt, tag_idx as tagIdx, title, public as isPublic from task where user_idx = ? and date = ?', [userIdx, date]);
   res.json(rows);
 });
 


### PR DESCRIPTION
## 요약
`snake_case`를 `camelCase`로 변경했습니다
- `started_at` → `startedAt`
- `ended_at` → `endedAt`
- `tag_idx` → `tagIdx`

예약어를 API 필드 이름으로 사용하지 않도록 변경했습니다.
- `public` → `isPublic`
## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/204445298-32c1ef9a-220c-4ef9-83cb-18f09ae0647a.png)
