### PR TITLE
[BE] [7-22] 라벨 생성시 idx를 반환하도록 수정

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -22,7 +22,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color, unit } = req.body;
   const result = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
-  res.status(200).send({ idx: result.insertId });
+  res.status(201).send({ idx: result.insertId });
 });
 
 export default router;

--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
+import { OkPacket } from 'mysql2';
 
 const router = Router();
 
@@ -20,8 +21,8 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color, unit } = req.body;
-  await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx]);
-  res.sendStatus(200);
+  const result = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
+  res.status(200).send({ idx: result.insertId });
 });
 
 export default router;


### PR DESCRIPTION
## 요약
라벨을 추가하는 API에서 idx 값을 반환하도록 수정했습니다.

## 작동 화면
<img width="630" alt="image" src="https://user-images.githubusercontent.com/73420533/204450785-a2e1a768-ca6e-4fb3-a101-eeb245d29ee5.png">

## 테스트 방법
로그인을 완료하세요.
개발자 도구를 열고 다음 코드를 입력하세요.
```
fetch('http://localhost:8000/api/v1/label', {
  method: 'post',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({title: '잠자기', color: '#776677', unit: '시간'}),
});
```
주소창에 http://localhost:8000/api/v1/label을 입력하세요.

## 관련 Task
- 7-22

## 비고
- 라벨을 생성 후 해당 라벨에 대한 task의 라벨 데이터를 등록해야 되기 때문에 필요
