### PR TITLE
[BE] [30] task 수정 API - 불필요한 타입 캐스팅 제거

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -158,13 +158,13 @@ router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res
       if (!tag) return res.status(404).json({ msg: '해당 태그를 찾을 수 없어요.' });
       if (tag.user_idx !== userIdx) return res.status(403).json({ msg: '태그 변경은 자신의 태그로만 가능해요.' });
       if (task.tag_idx === tagIdx) return res.status(409).json({ msg: '이미 해당 태그에요.' });
-      await executeSql('update task set tag_idx = ? where idx = ?', [tagIdx, taskIdx] as any); // TODO: executeSql 함수 매개변수 타입 수정 후 타입 캐스팅 삭제
+      await executeSql('update task set tag_idx = ? where idx = ?', [tagIdx, taskIdx]);
       status = 206;
     }
 
     if (done) {
       if (task.done === done) return res.sendStatus(status);
-      await executeSql('update task set done = ? where idx = ?', [done, taskIdx] as any); // TODO: executeSql 함수 매개변수 타입 수정 후 타입 캐스팅 삭제
+      await executeSql('update task set done = ? where idx = ?', [done, taskIdx]);
     }
     res.sendStatus(200);
   } catch (error) {


### PR DESCRIPTION
## 요약
`executeSql` 함수의 매개변수 타입스크립트 제약이 제거됨에 따라 불필요한 타입 캐스팅을 제거했습니다.