### PR TITLE
[BE] [23] 태스크 조회 API 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -10,22 +10,24 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { date } = req.query;
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
+  try {
+    const tasks = (await executeSql(
+      'select task.idx, task.title, task.importance, task.started_at as startedAt, task.ended_at as endedAt, task.lat, task.lng, task.location, task.public as isPublic, task.tag_idx as tagIdx, tag.title as tagName, task.content, task.done from task left join tag on task.tag_idx = tag.idx where task.user_idx = ? and task.date = ?',
+      [userIdx, date]
+    )) as RowDataPacket;
 
-  const tasks = (await executeSql(
-    'select task.idx, task.title, task.importance, task.started_at as startedAt, task.ended_at as endedAt, task.lat, task.lng, task.location, task.public as isPublic, task.tag_idx as tagIdx, tag.title as tagName, task.content, task.done from task left join tag on task.tag_idx = tag.idx where task.user_idx = ? and task.date = ?',
-    [userIdx, date]
-  )) as RowDataPacket;
-
-  const result = await Promise.all(
-    tasks.map(async (task: RowDataPacket) => {
-      const { idx: taskIdx } = task;
-      const labels = await executeSql('select label.idx as labelIdx, label.title, label.color, label.unit, task_label.amount from task_label inner join label on task_label.label_idx = label.idx where task_idx = ?', [taskIdx]);
-      task.labels = labels;
-      return task;
-    })
-  );
-
-  res.json(result);
+    const result = await Promise.all(
+      tasks.map(async (task: RowDataPacket) => {
+        const { idx: taskIdx } = task;
+        const labels = await executeSql('select label.idx as labelIdx, label.title, label.color, label.unit, task_label.amount from task_label inner join label on task_label.label_idx = label.idx where task_idx = ?', [taskIdx]);
+        task.labels = labels;
+        return task;
+      })
+    );
+    res.json(result);
+  } catch {
+    res.sendStatus(500);
+  }
 });
 
 const MIN_IMPORTANCE = 1;

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -10,8 +10,22 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { date } = req.query;
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
-  const rows = await executeSql('select * from task where user_idx = ? and date = ?', [userIdx, date]);
-  res.json(rows);
+
+  const tasks = (await executeSql(
+    'select task.idx, task.title, task.importance, task.started_at as startedAt, task.ended_at as endedAt, task.lat, task.lng, task.location, task.public as isPublic, task.tag_idx as tagIdx, tag.title as tagName, task.content, task.done from task left join tag on task.tag_idx = tag.idx where task.user_idx = ? and task.date = ?',
+    [userIdx, date]
+  )) as RowDataPacket;
+
+  const result = await Promise.all(
+    tasks.map(async (task: RowDataPacket) => {
+      const { idx: taskIdx } = task;
+      const labels = await executeSql('select label.idx as labelIdx, label.title, label.color, label.unit, task_label.amount from task_label inner join label on task_label.label_idx = label.idx where task_idx = ?', [taskIdx]);
+      task.labels = labels;
+      return task;
+    })
+  );
+
+  res.json(result);
 });
 
 const MIN_IMPORTANCE = 1;


### PR DESCRIPTION
## 요약
태스크 조회 시 라벨의 목록을 함께 반환하도록 API를 수정하였습니다.
- 요청 URL : `/task?date=${date}`
   - `date` : 태스크를 조회하고 싶은 날짜
   - method : `GET`
- 응답
   - `[ { idx, title, importance, startedAt, endedAt, lat, lng, location, isPublic, tagIdx, tagName, content, done, labels: [ { labelIdx, title, color, unit, amount } ] } ]` (태스크 객체 배열)
   - 날짜 미지정 : `400`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/task`을 통해 날짜 미지정 시 `400` 코드와 날짜를 지정하라는 메시지가 반환됨을 확인
2. `/task?date=2022-12-01`을 통해 태스크 목록 조회 시 라벨의 목록이 함께 조회됨을 확인
3. `/task?date=2022-11-29`을 통해 라벨이 설정되지 않은 태스크 조회 시 라벨의 목록이 빈 배열로 조회됨을 확인

[c0ff9136-79c5-4d43-9269-3a9fd2884985.webm](https://user-images.githubusercontent.com/92143119/204459351-72384c34-c901-41ef-b18f-9747cb7d8754.webm)

## 작업 내용
1. 태스크 조회 시 라벨 목록이 조회되도록 태스크 조회 API 수정
2. `try catch` 문을 통해 에러 처리

## 테스트 방법
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/task?date=${date}`를 입력합니다.

## 관련 Task
- [23]