### PR TITLE
[FE] [4-21] 검색창 통해 친구요청(API포함) 구현

### DIFF
--- a/client/src/components/FriendsBar/FriendSearchForm.tsx
+++ b/client/src/components/FriendsBar/FriendSearchForm.tsx
@@ -29,7 +29,7 @@ const FriendSearchForm = ({ selectedFriend, setSelectedFriend, handleRequestButt
         <FriendResultList>
           {friendObject &&
             friendObject.map(({ idx, userId, username, profileImg }) => {
-              return <FriendSearchResult idx={idx} userId={userId} username={username} profileImg={profileImg} selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} />;
+              return <FriendSearchResult key={idx} idx={idx} userId={userId} username={username} profileImg={profileImg} selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} />;
             })}
         </FriendResultList>
         <FriendRequestButton isSelectedFriendNull={selectedFriend === null} onClick={handleRequestButtonClick}>

--- a/client/src/components/FriendsBar/FriendSearchForm.tsx
+++ b/client/src/components/FriendsBar/FriendSearchForm.tsx
@@ -4,14 +4,22 @@ import styled from 'styled-components';
 import { HOST } from '../../constants';
 import FriendSearchInput from './FriendSearchInput';
 
+interface FriendSearchFormProps {
+  selectedFriend: number | null;
+  setSelectedFriend: React.Dispatch<React.SetStateAction<number | null>>;
+  handleRequestButtonClick: React.MouseEventHandler;
+}
+
 interface FriendSearchResultProps {
   idx: number;
   userId: string;
   username: string;
   profileImg: string;
+  selectedFriend: number | null;
+  setSelectedFriend: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
-const FriendSearchForm = () => {
+const FriendSearchForm = ({ selectedFriend, setSelectedFriend, handleRequestButtonClick }: FriendSearchFormProps) => {
   const [friendObject, setFriendObject] = useState<Friend[] | null>(null);
   return (
     <>
@@ -21,11 +29,12 @@ const FriendSearchForm = () => {
         <FriendResultList>
           {friendObject &&
             friendObject.map(({ idx, userId, username, profileImg }) => {
-              console.log(HOST, profileImg);
-              return <FriendSearchResult idx={idx} userId={userId} username={username} profileImg={profileImg} />;
+              return <FriendSearchResult idx={idx} userId={userId} username={username} profileImg={profileImg} selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} />;
             })}
         </FriendResultList>
-        <FriendRequestButton>Friend Request!</FriendRequestButton>
+        <FriendRequestButton isSelectedFriendNull={selectedFriend === null} onClick={handleRequestButtonClick}>
+          Friend Request!
+        </FriendRequestButton>
       </FriendSearchContainer>
     </>
   );
@@ -33,9 +42,12 @@ const FriendSearchForm = () => {
 
 export default FriendSearchForm;
 
-const FriendSearchResult = ({ idx, userId, username, profileImg }: FriendSearchResultProps) => {
+const FriendSearchResult = ({ idx, userId, username, profileImg, selectedFriend, setSelectedFriend }: FriendSearchResultProps) => {
+  const handleFriendClick = () => {
+    setSelectedFriend(idx);
+  };
   return (
-    <FriendResult>
+    <FriendResult isSelected={idx === selectedFriend} onClick={handleFriendClick}>
       <FriendProfile imgURL={HOST + '/' + profileImg}></FriendProfile>
       <FriendInfo>
         <span>
@@ -73,15 +85,20 @@ const FriendResultList = styled.div`
   height: 21rem;
   overflow-y: scroll;
 `;
-const FriendResult = styled.div`
+const FriendResult = styled.div<{
+  isSelected: boolean;
+}>`
   width: 21rem;
   height: 6.5rem;
   margin: 0 0 1rem;
-  padding: 1rem;
+  padding: ${({ isSelected }) => (isSelected ? '1rem 1rem 1rem 0.5rem' : '1rem')};
+  border: ${({ isSelected }) => (isSelected ? '0.5rem solid var(--color-main)' : 'none')};
   display: flex;
+  align-items: center;
   border-radius: 1rem;
   background: #f8f8f8;
   box-sizing: border-box;
+  cursor: pointer;
 `;
 
 const FriendProfile = styled.div<{
@@ -102,15 +119,16 @@ const FriendInfo = styled.div`
   justify-content: center;
 `;
 
-const FriendRequestButton = styled.button`
+const FriendRequestButton = styled.button<{ isSelectedFriendNull: boolean }>`
   width: 18.5rem;
   height: 2rem;
   border: none;
   border-radius: 1rem;
   margin: 0 auto;
-  background: var(--color-main);
+  background: ${(props) => (props.isSelectedFriendNull ? 'var(--color-gray3)' : 'var(--color-main)')};
   color: white;
   font-family: 'Press Start 2P', cursive;
   font-size: 0.875rem;
   text-align: center;
+  cursor: pointer;
 `;

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { HOST } from '../constants';
 import { Friend } from 'GlobalType';
 import FriendsBar from '../components/FriendsBar/FriendsBar';
@@ -12,10 +12,10 @@ import FriendSearchForm, { FRIEND_SEARCH_MODAL_ZINDEX } from '../components/Frie
 import { DRAWER_Z_INDEX } from '../components/Drawer/Drawer.style';
 import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM } from '../constants';
 
-
 const MainPage = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isFriendSearchFormOpen, setIsFriendSearchFormOpen] = useState(false);
+  const [selectedFriend, setSelectedFriend] = useState<number | null>(null);
   const [myProfile, setMyProfile] = useState<Friend | null>(null);
   const [friendsList, setFriendsList] = useState<Friend[] | null>(null);
 
@@ -32,10 +32,23 @@ const MainPage = () => {
     try {
       const response = await axios.get(`${HOST}/api/v1/user/me`);
       setMyProfile(response.data);
-      console.log(response.data);
     } catch (error) {
       console.log(error);
     }
+  };
+  const handleFriendSearchFormDimmedClick = () => {
+    setIsFriendSearchFormOpen(false);
+    setSelectedFriend(null);
+  };
+  const sendFriendRequest = async () => {
+    try {
+      const response = await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
+      if (response.status === 201) alert('친구요청을 완료했습니다');
+    } catch (error: any) {
+      alert(error.response.data.msg);
+    }
+    setSelectedFriend(null);
+    setIsFriendSearchFormOpen(false);
   };
 
   useEffect(() => {
@@ -51,7 +64,14 @@ const MainPage = () => {
       {isDrawerOpen && <Dimmed zIndex={DRAWER_Z_INDEX - 1} onClick={() => setIsDrawerOpen(false)} />}
       <Drawer open={isDrawerOpen} />
       {isFriendSearchFormOpen && (
-        <Modal component={<FriendSearchForm />} top={MODAL_CENTER_TOP} left={MODAL_CENTER_LEFT} transform={MODAL_CENTER_TRANSFORM} zIndex={FRIEND_SEARCH_MODAL_ZINDEX} handleDimmedClick={() => setIsFriendSearchFormOpen(false)} />
+        <Modal
+          component={<FriendSearchForm selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} handleRequestButtonClick={() => sendFriendRequest()} />}
+          top={MODAL_CENTER_TOP}
+          left={MODAL_CENTER_LEFT}
+          transform={MODAL_CENTER_TRANSFORM}
+          zIndex={FRIEND_SEARCH_MODAL_ZINDEX}
+          handleDimmedClick={() => handleFriendSearchFormDimmedClick()}
+        />
       )}
     </RecoilRoot>
   );


### PR DESCRIPTION
## 요약
친구 검색기능 통해 친구추가 요청 구현

## 작동 화면
![GIF 2022-11-29 오후 3-59-56](https://user-images.githubusercontent.com/109147404/204460816-23bbcae9-b1a8-4d2e-a96a-76b0e529a339.gif)

## 작업 내용
1.MainPage에서 친구추가 API 요청 로직을 제공합니다.
2.친구추가 컴포넌트에서 해당 로직을 받아 친구를 선택하여 친구요청을 서버로 보냅니다.
3.현재 상황(친구요청완료, 친구 기요청여부)을 response로받아 alert 메세지를 띄웁니다.

## 테스트 방법
1.로그인을하여 친구Bar에 있는 + 버튼을 누른다.
2.사용자를 검색한다.
3.친구로 추가하고자하는 사용자를 클릭하여 활성화된 request버튼을 누른다.

## 관련 Task
-[4-21]

## 비고
