### PR TITLE
[BE] [31] 라벨 생성 API 수정

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
-import { RowDataPacket } from 'mysql2';
+import { OkPacket, RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
-import { OkPacket } from 'mysql2';
 
 const router = Router();
 
@@ -22,26 +21,12 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color, unit } = req.body;
-  const result = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
-  res.status(201).send({ idx: result.insertId });
-});
 
-router.delete('/:label_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
-  const { userIdx } = req.user;
-  const labelIdx = req.params.label_idx;
+  const existLabel = ((await executeSql('select idx from label where user_idx = ? and title = ?', [userIdx, title])) as RowDataPacket).length > 0;
+  if (existLabel) return res.status(409).json({ msg: '이미 존재하는 라벨이에요.' });
 
-  try {
-    const notExistLabel = ((await executeSql('select idx from label where user_idx = ? and idx = ?', [userIdx, labelIdx])) as RowDataPacket).length === 0;
-    if (notExistLabel) return res.status(404).json({ msg: '존재하지 않는 라벨이에요.' });
-
-    const { labelUsageCount } = ((await executeSql('select count(ifnull(label_idx, 0)) as labelUsageCount from task_label where label_idx = ?', [labelIdx])) as RowDataPacket)[0];
-    if (labelUsageCount > 0) return res.status(409).json({ msg: '사용 중인 라벨은 삭제할 수 없어요.' });
-
-    await executeSql('delete from label where user_idx = ? and idx = ?', [userIdx, labelIdx]);
-    res.sendStatus(200);
-  } catch (error) {
-    res.sendStatus(500);
-  }
+  const { insertId } = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
+  res.status(200).send({ idx: insertId });
 });
 
 export default router;

--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -21,12 +21,15 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const { title, color, unit } = req.body;
+  try {
+    const existLabel = ((await executeSql('select idx from label where user_idx = ? and title = ?', [userIdx, title])) as RowDataPacket).length > 0;
+    if (existLabel) return res.status(409).json({ msg: '이미 존재하는 라벨이에요.' });
 
-  const existLabel = ((await executeSql('select idx from label where user_idx = ? and title = ?', [userIdx, title])) as RowDataPacket).length > 0;
-  if (existLabel) return res.status(409).json({ msg: '이미 존재하는 라벨이에요.' });
-
-  const { insertId } = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
-  res.status(201).send({ idx: insertId });
+    const { insertId } = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
+    res.status(201).send({ idx: insertId });
+  } catch {
+    res.sendStatus(500);
+  }
 });
 
 export default router;

--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -26,7 +26,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   if (existLabel) return res.status(409).json({ msg: '이미 존재하는 라벨이에요.' });
 
   const { insertId } = (await executeSql('insert into label (title, color, unit, user_idx) values (?, ?, ?, ?)', [title, color, unit, userIdx])) as OkPacket;
-  res.status(200).send({ idx: insertId });
+  res.status(201).send({ idx: insertId });
 });
 
 export default router;


### PR DESCRIPTION
## 요약
라벨 생성 시 이미 존재하는 title을 사용하면 서버 에러가 발생하던 현상을 수정하였습니다.
DB label 테이블에 `(user_idx, title)` 의 unique 조건이 존재하는데 DB 요청 전 이를 미리 검사하지 않아 발생한 현상이었습니다.
DB 요청 전 해당 사용자에게 이미 동일한 title의 라벨이 존재하는지 검사한 후 존재한다면 `409` 코드를 반환하는 코드를 추가하였습니다.
- 요청 URL : `/label`
   - `Request Body` : `{ title, color, unit }` (라벨 정보 객체)
   - method : `POST`
- 응답
   - `{ idx }` (생성된 라벨의 인덱스) : `201`
   - 이미 존재하는 라벨 : `409`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. 이미 존재하는 `수면` 라벨 생성 요청
2. `409` 코드가 반환되는 것을 확인

[6d68f345-a1e6-4f42-b7ed-e59a85506969.webm](https://user-images.githubusercontent.com/92143119/204477752-18752681-67d1-4c8c-9755-3a153cf94367.webm)

## 작업 내용
1. 이미 존재하는 title의 라벨 생성 요청 시 `409` 코드를 반환하도록 라벨 생성 API 수정
2. 라벨 생성 성공 시 `201` 코드를 반환하도록 수정
3. `try catch`를 통한 에러 처리

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/label', {
     method: 'post',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({title: ${title}, color: ${color}, unit: ${unit}}),
   });
   ```

## 관련 Task
- [31]