### PR TITLE
[FE] [4-19] 친구 요청 수락/거절 기능 구현

### DIFF
--- a/client/src/components/Drawer/Drawer.style.ts
+++ b/client/src/components/Drawer/Drawer.style.ts
@@ -16,7 +16,7 @@ const unselectable = `
   user-select: none;
 `;
 
-export const Drawer = styled.div<{ open: boolean }>`
+export const Drawer = styled.div<{ isOpen: boolean }>`
   position: fixed;
   display: flex;
   flex-direction: column;
@@ -28,7 +28,7 @@ export const Drawer = styled.div<{ open: boolean }>`
   padding: 0 ${DRAWER_HORIZON_PADDING};
   background-color: #ffffff;
   transition: all ease 1s;
-  ${(props) => props.open && `transform: translateX(${DRAWER_RIGHT});`}
+  ${(props) => props.isOpen && `transform: translateX(${DRAWER_RIGHT});`}
   img {
     ${unselectable}
   }

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -1,10 +1,29 @@
 import { useState } from 'react';
 import { dummyNotifications, dummyReceivedFriendRequests } from '../common/dummy';
 import { PROFILE_EDIT_FORM_Z_INDEX, PROFILE_EDIT_FORM_TOP, PROFILE_EDIT_FORM_LEFT, PROFILE_EDIT_FORM_TRANFORM } from './Drawer.style';
+import { FRIEND_REQUEST_ACTION, HOST } from '../../constants';
 import Modal from '../common/Modal';
+import { Friend } from 'GlobalType';
 import * as S from './Drawer.style';
 
-const Drawer = ({ open }: { open: boolean }) => {
+interface DrawerProps {
+  isOpen: boolean;
+  friendRequests: Friend[] | null;
+  handleFriendRequests: Function;
+}
+interface ReceivedFriendRequestSectionProps {
+  friendRequests: Friend[] | null;
+  handleFriendRequests: Function;
+}
+interface ReceivedFriendRequestProps {
+  idx: number;
+  userId: string;
+  username: string;
+  profileImg: string;
+  handleFriendRequests: Function;
+}
+
+const Drawer = ({ isOpen, friendRequests, handleFriendRequests }: DrawerProps) => {
   const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
 
   const handleProfileEditButtonClick = () => {
@@ -17,10 +36,10 @@ const Drawer = ({ open }: { open: boolean }) => {
 
   return (
     <>
-      <S.Drawer open={open}>
+      <S.Drawer isOpen={isOpen}>
         <ProfileSection handleProfileEditButtonClick={handleProfileEditButtonClick} />
         <S.HorizontalRule />
-        <ReceivedFriendRequestSection />
+        <ReceivedFriendRequestSection friendRequests={friendRequests} handleFriendRequests={handleFriendRequests} />
         <S.HorizontalRule />
         <NotificationSection />
         <S.LogoutButton onClick={handleLogoutButtonClick} href="#">
@@ -78,38 +97,28 @@ const ProfileSection = ({ handleProfileEditButtonClick }: ProfileSectionProps) =
   );
 };
 
-const ReceivedFriendRequestSection = () => {
+const ReceivedFriendRequestSection = ({ friendRequests, handleFriendRequests }: ReceivedFriendRequestSectionProps) => {
   return (
     <S.ReceivedFriendRequestSection>
       <S.SectionHeader>나에게 온 친구 요청</S.SectionHeader>
       <div>
-        {dummyReceivedFriendRequests.map(({ userId, username, profile_img }) => (
-          <ReceivedFriendRequest key={userId} userId={userId} username={username} profileImg={profile_img} />
-        ))}
+        {friendRequests && friendRequests.map(({ idx, userId, username, profileImg }) => <ReceivedFriendRequest key={userId} idx={idx} userId={userId} username={username} profileImg={profileImg} handleFriendRequests={handleFriendRequests} />)}
       </div>
     </S.ReceivedFriendRequestSection>
   );
 };
 
-const ReceivedFriendRequest = ({ userId, username, profileImg }: { userId: string; username: string; profileImg: string }) => {
-  const handleAcceptButtonClick = () => {
-    console.log('AcceptButtonClicked');
-  };
-
-  const handleRejectButtonClick = () => {
-    console.log('RejectButtonClicked');
-  };
-
+const ReceivedFriendRequest = ({ idx, userId, username, profileImg, handleFriendRequests }: ReceivedFriendRequestProps) => {
   return (
     <S.ReceivedFriendRequest>
-      <S.ProfileImage size="4rem" padding="1rem" src={profileImg} />
+      <S.ProfileImage size="4rem" padding="1rem" src={HOST + '/' + profileImg} />
       <S.ReceivedFriendRequestInfo>
         <S.Username>{username}</S.Username>
         <S.UserId>@{userId}</S.UserId>
       </S.ReceivedFriendRequestInfo>
       <S.ReceivedFriendRequestHandlingButtonSection>
-        <S.RecievedFriendRequestRejectButton onClick={handleRejectButtonClick} />
-        <S.RecievedFriendRequestAcceptButton onClick={handleAcceptButtonClick} />
+        <S.RecievedFriendRequestRejectButton onClick={() => handleFriendRequests(idx)(FRIEND_REQUEST_ACTION.REJECT)} />
+        <S.RecievedFriendRequestAcceptButton onClick={() => handleFriendRequests(idx)(FRIEND_REQUEST_ACTION.ACCEPT)} />
       </S.ReceivedFriendRequestHandlingButtonSection>
     </S.ReceivedFriendRequest>
   );

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { dummyNotifications, dummyReceivedFriendRequests } from '../common/dummy';
+import { dummyNotifications } from '../common/dummy';
 import { PROFILE_EDIT_FORM_Z_INDEX, PROFILE_EDIT_FORM_TOP, PROFILE_EDIT_FORM_LEFT, PROFILE_EDIT_FORM_TRANFORM } from './Drawer.style';
 import { FRIEND_REQUEST_ACTION, HOST } from '../../constants';
 import Modal from '../common/Modal';
@@ -22,6 +22,9 @@ interface ReceivedFriendRequestProps {
   profileImg: string;
   handleFriendRequests: Function;
 }
+interface ProfileSectionProps {
+  handleProfileEditButtonClick: React.MouseEventHandler;
+}
 
 const Drawer = ({ isOpen, friendRequests, handleFriendRequests }: DrawerProps) => {
   const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
@@ -31,7 +34,7 @@ const Drawer = ({ isOpen, friendRequests, handleFriendRequests }: DrawerProps) =
   };
 
   const handleLogoutButtonClick = () => {
-    console.log('LogoutButtonClicked');
+    console.log('LogoutButtonClicked(추후 로그아웃 API 추가)');
   };
 
   return (
@@ -74,10 +77,6 @@ const ProfileEditForm = () => {
   );
 };
 
-interface ProfileSectionProps {
-  handleProfileEditButtonClick: React.MouseEventHandler;
-}
-
 const ProfileSection = ({ handleProfileEditButtonClick }: ProfileSectionProps) => {
   return (
     <S.ProfileSection>
@@ -109,6 +108,8 @@ const ReceivedFriendRequestSection = ({ friendRequests, handleFriendRequests }: 
 };
 
 const ReceivedFriendRequest = ({ idx, userId, username, profileImg, handleFriendRequests }: ReceivedFriendRequestProps) => {
+  const rejectFriendRequest = handleFriendRequests(FRIEND_REQUEST_ACTION.REJECT);
+  const acceptFriendRequest = handleFriendRequests(FRIEND_REQUEST_ACTION.ACCEPT);
   return (
     <S.ReceivedFriendRequest>
       <S.ProfileImage size="4rem" padding="1rem" src={HOST + '/' + profileImg} />
@@ -117,8 +118,8 @@ const ReceivedFriendRequest = ({ idx, userId, username, profileImg, handleFriend
         <S.UserId>@{userId}</S.UserId>
       </S.ReceivedFriendRequestInfo>
       <S.ReceivedFriendRequestHandlingButtonSection>
-        <S.RecievedFriendRequestRejectButton onClick={() => handleFriendRequests(idx)(FRIEND_REQUEST_ACTION.REJECT)} />
-        <S.RecievedFriendRequestAcceptButton onClick={() => handleFriendRequests(idx)(FRIEND_REQUEST_ACTION.ACCEPT)} />
+        <S.RecievedFriendRequestRejectButton onClick={() => rejectFriendRequest(idx)} />
+        <S.RecievedFriendRequestAcceptButton onClick={() => acceptFriendRequest(idx)} />
       </S.ReceivedFriendRequestHandlingButtonSection>
     </S.ReceivedFriendRequest>
   );

--- a/client/src/components/FriendsBar/FriendSearchForm.tsx
+++ b/client/src/components/FriendsBar/FriendSearchForm.tsx
@@ -4,14 +4,22 @@ import styled from 'styled-components';
 import { HOST } from '../../constants';
 import FriendSearchInput from './FriendSearchInput';
 
+interface FriendSearchFormProps {
+  selectedFriend: number | null;
+  setSelectedFriend: React.Dispatch<React.SetStateAction<number | null>>;
+  handleRequestButtonClick: React.MouseEventHandler;
+}
+
 interface FriendSearchResultProps {
   idx: number;
   userId: string;
   username: string;
   profileImg: string;
+  selectedFriend: number | null;
+  setSelectedFriend: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
-const FriendSearchForm = () => {
+const FriendSearchForm = ({ selectedFriend, setSelectedFriend, handleRequestButtonClick }: FriendSearchFormProps) => {
   const [friendObject, setFriendObject] = useState<Friend[] | null>(null);
   return (
     <>
@@ -21,11 +29,12 @@ const FriendSearchForm = () => {
         <FriendResultList>
           {friendObject &&
             friendObject.map(({ idx, userId, username, profileImg }) => {
-              console.log(HOST, profileImg);
-              return <FriendSearchResult idx={idx} userId={userId} username={username} profileImg={profileImg} />;
+              return <FriendSearchResult idx={idx} userId={userId} username={username} profileImg={profileImg} selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} />;
             })}
         </FriendResultList>
-        <FriendRequestButton>Friend Request!</FriendRequestButton>
+        <FriendRequestButton isSelectedFriendNull={selectedFriend === null} onClick={handleRequestButtonClick}>
+          Friend Request!
+        </FriendRequestButton>
       </FriendSearchContainer>
     </>
   );
@@ -33,9 +42,12 @@ const FriendSearchForm = () => {
 
 export default FriendSearchForm;
 
-const FriendSearchResult = ({ idx, userId, username, profileImg }: FriendSearchResultProps) => {
+const FriendSearchResult = ({ idx, userId, username, profileImg, selectedFriend, setSelectedFriend }: FriendSearchResultProps) => {
+  const handleFriendClick = () => {
+    setSelectedFriend(idx);
+  };
   return (
-    <FriendResult>
+    <FriendResult isSelected={idx === selectedFriend} onClick={handleFriendClick}>
       <FriendProfile imgURL={HOST + '/' + profileImg}></FriendProfile>
       <FriendInfo>
         <span>
@@ -73,15 +85,20 @@ const FriendResultList = styled.div`
   height: 21rem;
   overflow-y: scroll;
 `;
-const FriendResult = styled.div`
+const FriendResult = styled.div<{
+  isSelected: boolean;
+}>`
   width: 21rem;
   height: 6.5rem;
   margin: 0 0 1rem;
-  padding: 1rem;
+  padding: ${({ isSelected }) => (isSelected ? '1rem 1rem 1rem 0.5rem' : '1rem')};
+  border: ${({ isSelected }) => (isSelected ? '0.5rem solid var(--color-main)' : 'none')};
   display: flex;
+  align-items: center;
   border-radius: 1rem;
   background: #f8f8f8;
   box-sizing: border-box;
+  cursor: pointer;
 `;
 
 const FriendProfile = styled.div<{
@@ -102,15 +119,16 @@ const FriendInfo = styled.div`
   justify-content: center;
 `;
 
-const FriendRequestButton = styled.button`
+const FriendRequestButton = styled.button<{ isSelectedFriendNull: boolean }>`
   width: 18.5rem;
   height: 2rem;
   border: none;
   border-radius: 1rem;
   margin: 0 auto;
-  background: var(--color-main);
+  background: ${(props) => (props.isSelectedFriendNull ? 'var(--color-gray3)' : 'var(--color-main)')};
   color: white;
   font-family: 'Press Start 2P', cursive;
   font-size: 0.875rem;
   text-align: center;
+  cursor: pointer;
 `;

--- a/client/src/components/common/dummy.ts
+++ b/client/src/components/common/dummy.ts
@@ -1,11 +1,3 @@
-export const dummyReceivedFriendRequests = [
-  {
-    userId: 'mikaniz',
-    username: '믹',
-    profile_img: 'https://avatars.githubusercontent.com/u/92143119?s=60&v=4',
-  },
-];
-
 export const dummyNotifications = [
   {
     idx: 330,

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 export const HOST = process.env.REACT_APP_MODE === 'dev' ? process.env.REACT_APP_DEV_HOST : process.env.REACT_APP_PROD_HOST;
 export const DEFAULT_PROFILE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460__480.png';
 export enum EngMonth {
@@ -54,4 +56,9 @@ export const DEFAULT_OBJECT_VALUE = {
   scaleY: 1,
   text: '텍스트를 입력하세요',
   fontSize: 24,
+};
+
+export const FRIEND_REQUEST_ACTION = {
+  ACCEPT: axios.patch,
+  REJECT: axios.delete,
 };

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
-import axios, { Axios, AxiosStatic } from 'axios';
-import { HOST, FRIEND_REQUEST_ACTION } from '../constants';
+import axios, { AxiosStatic } from 'axios';
+import { HOST } from '../constants';
 import { Friend } from 'GlobalType';
 import FriendsBar from '../components/FriendsBar/FriendsBar';
 import MainContents from '../components/MainContainer/MainContainer';
@@ -23,13 +23,13 @@ const MainPage = () => {
   //API Requests
   const getFriendsList = async () => {
     try {
-      setFriendsList(null);
       const response = await axios.get(`${HOST}/api/v1/friend`);
       setFriendsList(response.data);
     } catch (error) {
       console.log(error);
     }
   };
+
   const getMyProfile = async () => {
     try {
       const response = await axios.get(`${HOST}/api/v1/user/me`);
@@ -38,10 +38,7 @@ const MainPage = () => {
       console.log(error);
     }
   };
-  const handleFriendSearchFormDimmedClick = () => {
-    setIsFriendSearchFormOpen(false);
-    setSelectedFriend(null);
-  };
+
   const sendFriendRequest = async () => {
     try {
       const response = await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
@@ -49,23 +46,20 @@ const MainPage = () => {
     } catch (error: any) {
       alert(error.response.data.msg);
     }
-    setSelectedFriend(null);
-    setIsFriendSearchFormOpen(false);
+    resetFriendSearchForm();
   };
 
   const getFriendRequests = async () => {
     try {
       const response = await axios.get(`${HOST}/api/v1/friend/request`);
-      console.log(response.data);
       setFriendRequests(response.data);
     } catch (error) {
       console.log(error);
     }
   };
 
-  const handleFriendRequests = (idx: number) => {
-    const userIdx = idx;
-    return async function (action: AxiosStatic) {
+  const handleFriendRequests = (action: AxiosStatic) => {
+    return async function (userIdx: number) {
       try {
         const response = await action(`${HOST}/api/v1/friend/accept/${userIdx}`);
         alert(response.status);
@@ -75,6 +69,12 @@ const MainPage = () => {
       getFriendsList();
       getFriendRequests();
     };
+  };
+
+  //Event Handler
+  const resetFriendSearchForm = () => {
+    setIsFriendSearchFormOpen(false);
+    setSelectedFriend(null);
   };
 
   useEffect(() => {
@@ -97,7 +97,7 @@ const MainPage = () => {
           left={MODAL_CENTER_LEFT}
           transform={MODAL_CENTER_TRANSFORM}
           zIndex={FRIEND_SEARCH_MODAL_ZINDEX}
-          handleDimmedClick={() => handleFriendSearchFormDimmedClick()}
+          handleDimmedClick={() => resetFriendSearchForm()}
         />
       )}
     </RecoilRoot>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
-import axios from 'axios';
-import { HOST } from '../constants';
+import axios, { Axios, AxiosStatic } from 'axios';
+import { HOST, FRIEND_REQUEST_ACTION } from '../constants';
 import { Friend } from 'GlobalType';
 import FriendsBar from '../components/FriendsBar/FriendsBar';
 import MainContents from '../components/MainContainer/MainContainer';
@@ -12,13 +12,15 @@ import FriendSearchForm, { FRIEND_SEARCH_MODAL_ZINDEX } from '../components/Frie
 import { DRAWER_Z_INDEX } from '../components/Drawer/Drawer.style';
 import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM } from '../constants';
 
-
 const MainPage = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isFriendSearchFormOpen, setIsFriendSearchFormOpen] = useState(false);
+  const [selectedFriend, setSelectedFriend] = useState<number | null>(null);
   const [myProfile, setMyProfile] = useState<Friend | null>(null);
   const [friendsList, setFriendsList] = useState<Friend[] | null>(null);
+  const [friendRequests, setFriendRequests] = useState<Friend[] | null>(null);
 
+  //API Requests
   const getFriendsList = async () => {
     try {
       setFriendsList(null);
@@ -32,15 +34,55 @@ const MainPage = () => {
     try {
       const response = await axios.get(`${HOST}/api/v1/user/me`);
       setMyProfile(response.data);
-      console.log(response.data);
     } catch (error) {
       console.log(error);
     }
   };
 
+  const handleFriendSearchFormDimmedClick = () => {
+    setIsFriendSearchFormOpen(false);
+    setSelectedFriend(null);
+  };
+
+  const sendFriendRequest = async () => {
+    try {
+      const response = await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
+      if (response.status === 201) alert('친구요청을 완료했습니다');
+    } catch (error: any) {
+      alert(error.response.data.msg);
+    }
+    setSelectedFriend(null);
+    setIsFriendSearchFormOpen(false);
+  };
+
+  const getFriendRequests = async () => {
+    try {
+      const response = await axios.get(`${HOST}/api/v1/friend/request`);
+      console.log(response.data);
+      setFriendRequests(response.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleFriendRequests = (idx: number) => {
+    const userIdx = idx;
+    return async function (action: AxiosStatic) {
+      try {
+        const response = await action(`${HOST}/api/v1/friend/accept/${userIdx}`);
+        alert(response.status);
+      } catch (error) {
+        console.log(error);
+      }
+      getFriendsList();
+      getFriendRequests();
+    };
+  };
+
   useEffect(() => {
     getFriendsList();
     getMyProfile();
+    getFriendRequests();
   }, []);
 
   return (
@@ -49,9 +91,16 @@ const MainPage = () => {
       <FriendsBar myProfile={myProfile} friendsList={friendsList} handlePlusButtonClick={() => setIsFriendSearchFormOpen(true)} />
       <MainContents />
       {isDrawerOpen && <Dimmed zIndex={DRAWER_Z_INDEX - 1} onClick={() => setIsDrawerOpen(false)} />}
-      <Drawer open={isDrawerOpen} />
+      <Drawer isOpen={isDrawerOpen} friendRequests={friendRequests} handleFriendRequests={handleFriendRequests} />
       {isFriendSearchFormOpen && (
-        <Modal component={<FriendSearchForm />} top={MODAL_CENTER_TOP} left={MODAL_CENTER_LEFT} transform={MODAL_CENTER_TRANSFORM} zIndex={FRIEND_SEARCH_MODAL_ZINDEX} handleDimmedClick={() => setIsFriendSearchFormOpen(false)} />
+        <Modal
+          component={<FriendSearchForm selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} handleRequestButtonClick={() => sendFriendRequest()} />}
+          top={MODAL_CENTER_TOP}
+          left={MODAL_CENTER_LEFT}
+          transform={MODAL_CENTER_TRANSFORM}
+          zIndex={FRIEND_SEARCH_MODAL_ZINDEX}
+          handleDimmedClick={() => setIsFriendSearchFormOpen(false)}
+        />
       )}
     </RecoilRoot>
   );

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -101,17 +101,19 @@ declare module 'GlobalType' {
     unit: string;
     count: number?;
     amount: number?;
-}
+  }
 
-type ShapeType = 'rect' | 'triangle' | 'circle';
+  type ShapeType = 'rect' | 'triangle' | 'circle';
   interface ObjectData {
     [key: string]: FabricLine | FabricText | Shape;
   }
-  
+
   interface FabricObject extends fabric.Object {
     id: string;
   }
 }
+
+type FreindRequestAction = 'accept' | 'deny';
 
 interface ModalProps {
   component: JSX.Element;


### PR DESCRIPTION
## 요약
자신에게 온 친구 요청을 확인하고 수락하거나 거절할 수 있습니다.

## 작동 화면
![친구수락](https://user-images.githubusercontent.com/109147404/204558550-c718710c-fe7a-4717-8fdb-457473c01bcd.gif)
첫번째는 거절/ 두번째 수락(친구목록 리셋)

## 작업 내용
1.친구요청목록 수신 API를 이용하여 친구요청 목록을 불러와 렌더링합니다.
2. 각 친구요청 목록에 있는 수락/거절 버튼을 누르면 친구요청을 수락하거나 거절할 수 있습니다.

## 테스트 방법
1. 서로 친구가 아닌 계정이 2개 필요합니다.
2. 한 계정에서 다른 계정으로 친구 요청을 보냅니다.
3. 친구 요청을 보낸 계정으로 접속하여 친구요청을 확인합니다.
4. 거절하거나 수락하여 기능을 확인합니다.

## 관련 Task
-[4-19]

## 비고
