### PR TITLE
[BE] [4-25] 친구의 태스크 조회 API 구현

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -3,6 +3,7 @@ import { OkPacket, RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
+import { API_VERSION } from '../constants';
 
 const router = Router();
 
@@ -41,6 +42,8 @@ router.get('/:user_id', authenticateToken, async (req: AuthorizedRequest, res) =
     if (friend.length === 0) return res.status(404).send({ msg: '존재하지 않는 사용자예요.' });
 
     const { idx: friendIdx } = friend[0];
+    if (userIdx === friendIdx) return res.redirect(`/api/${API_VERSION}/task?date=${date}`);
+
     const isNotFriend = ((await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket).length === 0;
     if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 태스크를 조회할 수 없어요.' });
 


### PR DESCRIPTION
## 요약
친구의 태스크를 조회할 수 있는 API를 구현하였습니다.
친구인 사용자에 한해서만 태스크를 조회할 수 있으며 친구인 경우에도 공개(`public = true`)인 태스크만 조회할 수 있도록 하였습니다.
- 요청 URL : `/task/:user_id?date=${date}`
   - `user_id` : 조회하고 싶은 친구의 id
   - `date` : 태스크를 조회하고 싶은 날짜
   - method : `GET`
- 응답
   - `[ { idx, title, importance, startedAt, endedAt, lat, lng, location, isPublic, tagIdx, tagName, content, done, labels: [ { labelIdx, title, color, unit, amount } ] } ]` (태스크 객체 배열)
   - 자신에 대한 요청 : `/task?date=${date}`로 redirect 처리하여 자신의 태스크를 조회하는 API 요청
   - 날짜 미지정 : `400`
   - 친구가 아닌 사용자에 대한 요청 : `403`
   - 존재하지 않는 사용자에 대한 요청 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 날짜 미지정 요청, 존재하지 않는 사용자에 대한 요청
1. `/task/ss`을 통해 날짜 미지정 시 `400` 코드와 날짜를 지정하라는 메시지가 반환됨을 확인
2. 존재하지 않는 사용자 `ss`에 대한 요청인 `/task/ss?date=2022-12-01`을 통해 `404` 코드와 존재하지 않는 사용자라는 메시지가 반환됨을 확인

[0c6ac046-1357-4fd2-93af-6cb004a66dbb.webm](https://user-images.githubusercontent.com/92143119/204714811-60abab4c-d7c4-4a1c-9379-ed6ed8afdbb1.webm)
### 친구가 아닌 사용자에 대한 요청, 친구의 태스크 조회 요청
1. `/friend`를 통해 친구 목록 확인
2. 친구가 아닌 사용자 `j0702`에 대한 요청인 `/task/j0702?date=2022-11-29`을 통해 `403` 코드와 친구가 아닌 사용자의 태스크를 조회할 수 없다는 메시지가 반환됨을 확인
3. 친구인 사용자 `sy`에 대한 요청인 `/task/sy?date=2022-11-29`을 통해 `isPublic = 1`인 태스크의 목록이 조회되는 것을 확인

[ef741a69-c565-4a46-a2d4-f63c5dcb19ae.webm](https://user-images.githubusercontent.com/92143119/204714832-eed8583c-008f-4d19-b3ea-5b1a00b9ce2e.webm)
### 자신에 대한 요청
1. 자신의 아이디 `pikachu`에 대한 요청인 `/task/pikachu?date=2022-11-29`을 통해 `/task?date=2022-11-29`로 redirect 처리되는 것을 확인

[4c9464ac-0934-4113-84ea-c347dcc11a1e.webm](https://user-images.githubusercontent.com/92143119/204714845-cbffc613-1639-45e3-b150-4f3ca3087ebc.webm)


## 작업 내용
1. 친구의 태스크 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 주소창에 `http://localhost:8000/api/v1/task/${user_id}?date=${date}`를 입력합니다.

## 관련 Task
- [4-25]