### PR TITLE
[BE] [6-11] 사용자/날짜별 별도의 room에서 diary 작성 구현 완료

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { RecoilRoot } from 'recoil';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import PrivateRoute from './routes/PrivateRoute';
 import RestrictedRoute from './routes/RestrictedRoute';
@@ -12,14 +13,16 @@ import Drawer from './components/Drawer/Drawer';
 
 function App() {
   return (
-    <Router>
-      <GlobalStyle />
-      <Routes>
-        <Route path={RoutePath.ROOT} element={<RestrictedRoute component={WelcomePage} />} />
-        <Route path={RoutePath.SIGNUP} element={<SignupPage />} />
-        <Route path={RoutePath.MAIN} element={<PrivateRoute component={MainPage} />} />
-      </Routes>
-    </Router>
+    <RecoilRoot>
+      <Router>
+        <GlobalStyle />
+        <Routes>
+          <Route path={RoutePath.ROOT} element={<RestrictedRoute component={WelcomePage} />} />
+          <Route path={RoutePath.SIGNUP} element={<SignupPage />} />
+          <Route path={RoutePath.MAIN} element={<PrivateRoute component={MainPage} />} />
+        </Routes>
+      </Router>
+    </RecoilRoot>
   );
 }
 

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
+import { useRecoilState } from 'recoil';
 import { Friend } from 'GlobalType';
 import * as S from './FriendsBar.style';
+import { visitState } from '../common/atoms';
 
 interface FriendsBarProps {
   myProfile: Friend | null;
   friendsList: Friend[] | null;
   handlePlusButtonClick: React.MouseEventHandler;
 }
+interface ProfileBoxProps {
+  userId: string;
+  profileImg: string;
+}
+
 const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
 
   return (
     <>
       <S.FriendsBarContainer>
-        {myProfile && <S.ProfileBox imgURL={myProfile.profileImg}></S.ProfileBox>}
+        {myProfile && <ProfileBox userId={myProfile.userId} profileImg={myProfile.profileImg} />}
         {friendsList &&
-          friendsList.map(({ idx, userId, profileImg }) => {
-            return <S.ProfileBox key={userId} data-idx={idx} imgURL={profileImg}></S.ProfileBox>;
+          friendsList.map(({ userId, profileImg }) => {
+            return <ProfileBox key={userId} userId={userId} profileImg={profileImg} />;
           })}
         <S.ProfileBox imgURL={plusIcon} onClick={handlePlusButtonClick}></S.ProfileBox>
       </S.FriendsBarContainer>
@@ -25,3 +32,8 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
 };
 
 export default FriendsBar;
+
+const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+  return <S.ProfileBox imgURL={profileImg} onClick={() => setCurrentVisit(userId)}></S.ProfileBox>;
+};

--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -237,7 +237,6 @@ const Canvas = () => {
 
   const updateModifiedObject = (objectData: FabricLine | FabricText | Shape) => {
     const objectId = objectData.id;
-    console.log('draw', objectId);
     const objectType = objectData.type;
     const targetObject = diaryObjects.get(objectId);
     if (!canvasRef.current) return;
@@ -258,6 +257,20 @@ const Canvas = () => {
 
   const dispatchCanvasChange = (objectData: FabricLine | FabricText | Shape) => {
     globalSocket.emit('sendModifiedObject', objectData);
+  };
+
+  const setCanvasBackground = () => {
+    fabric.Image.fromURL('/canvasBackground.png', function (img) {
+      img.set({
+        top: 0,
+        left: 0,
+        evented: false,
+      });
+      img.scaleToWidth(660);
+      img.setCoords();
+      if (!canvasRef.current) return;
+      canvasRef.current.add(img);
+    });
   };
 
   globalSocket.once('offerCurrentObjects', (objectdataMap) => {
@@ -282,6 +295,7 @@ const Canvas = () => {
       globalSocket.off('applyObjectRemoving', removeObject);
       window.removeEventListener('keydown', handleKeydown);
       canvasRef.current.clear();
+      setCanvasBackground();
     };
   });
 

--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import globalSocket from '../common/Socket';
 import { DEFAULT_OBJECT_VALUE } from '../../constants';
 import { Shape, FabricText, FabricLine, ShapeType, FabricObject } from 'GlobalType';
 import { fabric } from 'fabric';
 import { v4 } from 'uuid';
+import { visitState } from '../common/atoms';
 
 const Canvas = () => {
+  const currentVisit = useRecoilValue(visitState);
   const canvasRef = useRef<fabric.Canvas | null>(null);
   const colorRef = useRef<HTMLInputElement | null>(null);
   const canvasBackground = '/canvasBackground.png';

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,9 +1,27 @@
 import { useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { visitState } from '../common/atoms';
+import globalSocket from '../common/Socket';
 import Canvas from './Canvas';
 import * as S from './Diary.style';
 import DateSelector from './DateSelector';
+import useCurrentDate from '../../hooks/useCurrentDate';
 
 const Diary = () => {
+  const currentVisit = useRecoilValue(visitState);
+  const { currentDate, getYear, getMonth, getDate } = useCurrentDate();
+  const createDateString = () => {
+    return `${getYear()}${(getMonth() + 1).toString().padStart(2, '0')}${getDate().toString().padStart(2, '0')}`;
+  };
+
+  useEffect(() => {
+    const currentDateString = createDateString();
+    globalSocket.emit('joinToNewRoom', currentVisit, currentDateString);
+    globalSocket.emit('requestCurrentObjects');
+    return () => {
+      globalSocket.emit('leaveCurrentRoom', currentVisit, currentDateString);
+    };
+  }, [currentVisit, currentDate]);
   return (
     <>
       <S.DiaryTitle>Diary</S.DiaryTitle>

--- a/client/src/components/common/Socket.ts
+++ b/client/src/components/common/Socket.ts
@@ -12,6 +12,8 @@ interface ClientToServerEvents {
   sendModifiedObject: (objectData: FabricLine | FabricText | Shape) => void;
   sendRemovedObjectId: (objectId: string) => void;
   requestCurrentObjects: () => void;
+  joinToNewRoom: (destId: string, date: string) => void;
+  leaveCurrentRoom: (destId: string, date: string) => void;
 }
 
 class GlobalSocket {

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -4,3 +4,7 @@ export const dateState = atom({
   key: 'currentDate',
   default: new Date(),
 });
+export const visitState = atom({
+  key: 'currentVisiting',
+  default: '',
+});

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,11 +5,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,7 +5,11 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { RecoilRoot } from 'recoil';
-import axios, { AxiosError } from 'axios';
-import { HOST } from '../constants';
+import { useRecoilState } from 'recoil';
+import { visitState } from '../components/common/atoms';
+import axios from 'axios';
 import { Friend } from 'GlobalType';
 import FriendsBar from '../components/FriendsBar/FriendsBar';
 import MainContents from '../components/MainContainer/MainContainer';
@@ -10,7 +10,7 @@ import TopBar from '../components/TopBar/TopBar';
 import Modal, { Dimmed } from '../components/common/Modal';
 import FriendSearchForm, { FRIEND_SEARCH_MODAL_ZINDEX } from '../components/FriendsBar/FriendSearchForm';
 import { DRAWER_Z_INDEX } from '../components/Drawer/Drawer.style';
-import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM } from '../constants';
+import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM, HOST } from '../constants';
 
 const MainPage = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -18,10 +18,10 @@ const MainPage = () => {
   const [selectedFriend, setSelectedFriend] = useState<number | null>(null);
   const [myProfile, setMyProfile] = useState<Friend | null>(null);
   const [friendsList, setFriendsList] = useState<Friend[] | null>(null);
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
 
   const getFriendsList = async () => {
     try {
-      setFriendsList(null);
       const response = await axios.get(`${HOST}/api/v1/friend`);
       setFriendsList(response.data);
     } catch (error) {
@@ -32,6 +32,7 @@ const MainPage = () => {
     try {
       const response = await axios.get(`${HOST}/api/v1/user/me`);
       setMyProfile(response.data);
+      return response.data;
     } catch (error) {
       console.log(error);
     }
@@ -53,11 +54,13 @@ const MainPage = () => {
 
   useEffect(() => {
     getFriendsList();
-    getMyProfile();
+    getMyProfile().then((userData: Friend) => {
+      setCurrentVisit(userData.userId);
+    });
   }, []);
 
   return (
-    <RecoilRoot>
+    <>
       <TopBar handleMenuClick={() => setIsDrawerOpen(true)} />
       <FriendsBar myProfile={myProfile} friendsList={friendsList} handlePlusButtonClick={() => setIsFriendSearchFormOpen(true)} />
       <MainContents />
@@ -73,7 +76,7 @@ const MainPage = () => {
           handleDimmedClick={() => handleFriendSearchFormDimmedClick()}
         />
       )}
-    </RecoilRoot>
+    </>
   );
 };
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -46,7 +46,6 @@ io.on('connection', (socket) => {
     visitingRoom.delete(socket.id);
   });
   socket.on('requestCurrentObjects', () => {
-    console.log('requested');
     const roomName = visitingRoom.get(socket.id);
     if (!diaryObjects[roomName]) diaryObjects[roomName] = {};
     const targetObjects = diaryObjects[roomName];


### PR DESCRIPTION
## 요약
사용자/날짜별  별도의 room에 입장해서 해당 room 사용자끼리 object 공유
## 작동 화면
![캔버스소켓](https://user-images.githubusercontent.com/109147404/204728969-ceac2f77-8e9e-4049-92a3-f7ee7f9390e5.gif)

## 작업 내용
1.방문중인 사용자의 ID 상태관리
2.diary탭에 입장시 방문중은 사용자의 ID와 현재연월일 8자리를 합쳐 roomName으로 지정
3.사용자/날짜별로 다른 object set에 접근할 수 있음

## 테스트 방법
1.로그인하여 diary탭에 진입한다.
2. 여러날짜와 여러 사용자에 접근하여 각각 사용자/날짜별로 object가 관리되는지 확인한다.

## 관련 Task
-[6-11]

## 비고
리액트 strictmode 사용시 현재 object가 2번 불러와지는 현상이 있습니다.