### PR TITLE
[FE] [22] 화면이 짤리는 이슈 등을 포함한 화면 전반의 css 조정

### DIFF
--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { HOST } from '../../constants';
 
 export const FriendsBarContainer = styled.div`
-  width: 69rem;
+  width: 70.5rem;
   height: 3rem;
   background: white;
   border-radius: 0.8rem;

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -11,16 +11,14 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
   const plusIcon = '/plus.svg';
 
   return (
-    <>
-      <S.FriendsBarContainer>
-        {myProfile && <S.ProfileBox imgURL={myProfile.profileImg}></S.ProfileBox>}
-        {friendsList &&
-          friendsList.map(({ idx, userId, profileImg }) => {
-            return <S.ProfileBox key={userId} data-idx={idx} imgURL={profileImg}></S.ProfileBox>;
-          })}
-        <S.ProfileBox imgURL={plusIcon} onClick={handlePlusButtonClick}></S.ProfileBox>
-      </S.FriendsBarContainer>
-    </>
+    <S.FriendsBarContainer>
+      {myProfile && <S.ProfileBox imgURL={myProfile.profileImg}></S.ProfileBox>}
+      {friendsList &&
+        friendsList.map(({ idx, userId, profileImg }) => {
+          return <S.ProfileBox key={userId} data-idx={idx} imgURL={profileImg}></S.ProfileBox>;
+        })}
+      <S.ProfileBox imgURL={plusIcon} onClick={handlePlusButtonClick}></S.ProfileBox>
+    </S.FriendsBarContainer>
   );
 };
 

--- a/client/src/components/MainContainer/Calendar.style.ts
+++ b/client/src/components/MainContainer/Calendar.style.ts
@@ -10,15 +10,13 @@ export const CalendarTitle = styled.span`
 `;
 export const CalendarContainer = styled.div`
   width: 100%;
-  height: 36rem;
+  height: 37rem;
   background: white;
   border-radius: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0.5rem;
   align-items: center;
-  margin-top: 0rem;
   box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
   user-select: none;
 `;

--- a/client/src/components/MainContainer/Diary.style.ts
+++ b/client/src/components/MainContainer/Diary.style.ts
@@ -9,8 +9,9 @@ export const DiaryTitle = styled.span`
   z-index: 1;
 `;
 
+export const Container = styled.div``;
+
 export const DiaryContainer = styled.div`
-  width: 100%;
   height: 36rem;
   background: white;
   border-radius: 1rem;

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -6,13 +6,15 @@ import DateSelector from './DateSelector';
 const Diary = () => {
   return (
     <>
-      <S.DiaryTitle>Diary</S.DiaryTitle>
-      <S.DiaryContainer>
-        <S.DiaryNavBarSection>
-          <DateSelector />
-        </S.DiaryNavBarSection>
-        <Canvas />
-      </S.DiaryContainer>
+      <S.DiaryTitle>DIARY</S.DiaryTitle>
+      <S.Container>
+        <S.DiaryContainer>
+          <S.DiaryNavBarSection>
+            <DateSelector />
+          </S.DiaryNavBarSection>
+          <Canvas />
+        </S.DiaryContainer>
+      </S.Container>
     </>
   );
 };

--- a/client/src/components/MainContainer/Log.style.ts
+++ b/client/src/components/MainContainer/Log.style.ts
@@ -37,13 +37,19 @@ export const TimeBarSection = styled.div`
   align-items: center;
   grid-area: time;
   cursor: default;
+
+  img {
+    width: 22px;
+    height: 22px;
+    filter: opacity(0.7);
+  }
 `;
 
 export const TimeBar = styled.div`
-  width: 0.8rem;
+  width: 13px;
   height: 31.2rem;
   position: relative;
-  margin: 0.75rem 0 0;
+  margin: 0.5rem 0 0 0;
   border: 2px solid #e3e3e3;
   border-radius: 0.5rem;
 `;
@@ -51,7 +57,9 @@ export const TimeMarker = styled.div<{
   startedAt: number;
   duration: number;
 }>`
-  width: 0.85rem;
+  margin-left: 2px;
+  width: 0.55rem;
+  border-radius: 5rem;
   height: ${(props) => props.duration * 1.3}rem;
   position: absolute;
   background: var(--color-main);
@@ -89,7 +97,7 @@ export const SortOptionSelect = styled.select`
 
 export const LogMainSection = styled.div`
   width: 100%;
-  height: fit-content;
+  height: 100%;
   display: flex;
   flex-wrap: no-wrap;
   overflow-x: scroll;

--- a/client/src/components/MainContainer/Log.style.ts
+++ b/client/src/components/MainContainer/Log.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { FiPlus } from 'react-icons/fi';
 
 export const LogTitle = styled.span`
   display: inline-block;
@@ -9,16 +10,15 @@ export const LogTitle = styled.span`
   z-index: 1;
 `;
 
+export const Container = styled.div``;
+
 export const LogContainer = styled.div`
-  width: 100%;
+  display: grid;
+  padding: 0.5rem;
   height: 36rem;
   background: white;
   border-radius: 1rem;
-  margin-top: 0rem;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
   position: relative;
-  display: grid;
   grid-template-areas:
     'time nav'
     'time main';
@@ -72,7 +72,7 @@ export const LogNavBarSection = styled.div`
 `;
 
 export const SortOptionSelect = styled.select`
-  margin-right: 1.25rem;
+  width: 5rem;
   border-radius: 0.5rem;
   margin-left: 1rem;
   color: #616161;
@@ -80,6 +80,7 @@ export const SortOptionSelect = styled.select`
   text-align: center;
   font-family: 'Noto Sans KR', sans-serif;
   option {
+    width: 3rem;
     color: #616161;
     font-size: 0.625rem;
     font-family: 'Noto Sans KR', sans-serif;
@@ -182,7 +183,7 @@ export const SlideObserver = styled.div<{
   direction: string;
 }>`
   width: 3rem;
-  height: 100%;
+  height: 33rem;
   position: absolute;
   z-index: 7;
   ${(props) => (props.direction === 'right' ? 'right: 0;' : 'left: 0;')}
@@ -225,4 +226,20 @@ export const CheckBox = styled.input`
 
 export const DateArrow = styled.div`
   cursor: pointer;
+`;
+
+export const PlusButton = styled(FiPlus)`
+  cursor: pointer;
+  position: absolute;
+  color: white;
+  font-size: 1.6rem;
+  left: 40.5rem;
+  bottom: 1rem;
+  padding: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 20rem;
+  background-color: var(--color-main);
+  box-shadow: 0px 0px 5px 3px rgba(175, 175, 175, 0.2);
+  z-index: 999;
 `;

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -166,42 +166,44 @@ const Log = () => {
         </S.SelectedItem>
       )}
       <S.LogTitle>LOG</S.LogTitle>
-      <S.LogContainer>
-        <S.TimeBarSection>
-          <img src="/timebar-clock.svg" alt="TimeBar" />
-          <S.TimeBar>
-            <S.TimeMarker startedAt={timeMarkerData[0]} duration={timeMarkerData[1]}></S.TimeMarker>
-          </S.TimeBar>
-        </S.TimeBarSection>
-        <S.LogNavBarSection>
-          <S.SortOptionSelect>
-            <option value="tag">태그순</option>
-            <option value="time">시간순</option>
-            <option value="importance">중요도순</option>
-          </S.SortOptionSelect>
-          <DateSelector />
-          <S.CheckBoxContainer>
-            <S.CheckBoxLabel htmlFor="complete">완료</S.CheckBoxLabel>
-            <S.CheckBox type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />
-            <S.CheckBoxLabel htmlFor="incomplete">미완료</S.CheckBoxLabel>
-            <S.CheckBox type="checkbox" id="incomplete" defaultChecked={completionCheckBoxStatus.incomplete} onChange={(e) => handleCheckBoxChange(e, 'incomplete')} />
-          </S.CheckBoxContainer>
-        </S.LogNavBarSection>
-        <S.LogMainSection ref={taskContainerRef}>
-          <S.SlideObserver data-direction="left" direction="left"></S.SlideObserver>
-          {tagList.map((tag) => {
-            return (
-              <S.TagWrap key={tag.idx} data-tag={tag.idx} onClick={handleTagWrapClick} onMouseDown={handleMouseDown}>
-                <S.TagTitle color={tag.color} data-tag={tag.idx}>
-                  #{tag.title}
-                </S.TagTitle>
-                <TaskList taskList={getFilteredTaskListbyTag(tag.idx)} activeTask={activeTask} completionFilter={completionCheckBoxStatus} />
-              </S.TagWrap>
-            );
-          })}
-          <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
-        </S.LogMainSection>
-      </S.LogContainer>
+      <S.Container>
+        <S.LogContainer>
+          <S.TimeBarSection>
+            <img src="/timebar-clock.svg" alt="TimeBar" />
+            <S.TimeBar>
+              <S.TimeMarker startedAt={timeMarkerData[0]} duration={timeMarkerData[1]}></S.TimeMarker>
+            </S.TimeBar>
+          </S.TimeBarSection>
+          <S.LogNavBarSection>
+            <S.SortOptionSelect>
+              <option value="tag">태그순</option>
+              <option value="time">시간순</option>
+              <option value="importance">중요도순</option>
+            </S.SortOptionSelect>
+            <DateSelector />
+            <S.CheckBoxContainer>
+              <S.CheckBoxLabel htmlFor="complete">완료</S.CheckBoxLabel>
+              <S.CheckBox type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />
+              <S.CheckBoxLabel htmlFor="incomplete">미완료</S.CheckBoxLabel>
+              <S.CheckBox type="checkbox" id="incomplete" defaultChecked={completionCheckBoxStatus.incomplete} onChange={(e) => handleCheckBoxChange(e, 'incomplete')} />
+            </S.CheckBoxContainer>
+          </S.LogNavBarSection>
+          <S.LogMainSection ref={taskContainerRef}>
+            <S.SlideObserver data-direction="left" direction="left"></S.SlideObserver>
+            {tagList.map((tag) => {
+              return (
+                <S.TagWrap key={tag.idx} data-tag={tag.idx} onClick={handleTagWrapClick} onMouseDown={handleMouseDown}>
+                  <S.TagTitle color={tag.color} data-tag={tag.idx}>
+                    #{tag.title}
+                  </S.TagTitle>
+                  <TaskList taskList={getFilteredTaskListbyTag(tag.idx)} activeTask={activeTask} completionFilter={completionCheckBoxStatus} />
+                </S.TagWrap>
+              );
+            })}
+            <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
+          </S.LogMainSection>
+        </S.LogContainer>
+      </S.Container>
     </>
   );
 };

--- a/client/src/components/MainContainer/MainContainer.style.ts
+++ b/client/src/components/MainContainer/MainContainer.style.ts
@@ -1,22 +1,23 @@
 import styled from 'styled-components';
+
 export const Container = styled.div`
-  width: 100vw;
-  display: grid;
+  display: flex;
   justify-content: center;
 `;
 
 export const MainContentContainer = styled.div`
-  width: 70rem;
+  margin: 0rem 4rem 0rem 4rem;
+  width: 71.5rem;
+  height: 40rem;
   display: flex;
   justify-content: space-between;
-  height: 0rem;
 `;
 export const LeftSection = styled.div`
-  width: 24.6rem;
+  width: 25.6rem;
 `;
 
 export const RightSection = styled.div`
-  width: 43.7rem;
+  width: 44.7rem;
 `;
 
 export const NewTaskButton = styled.div`

--- a/client/src/components/MainContainer/MainContainer.style.ts
+++ b/client/src/components/MainContainer/MainContainer.style.ts
@@ -19,19 +19,3 @@ export const LeftSection = styled.div`
 export const RightSection = styled.div`
   width: 44.7rem;
 `;
-
-export const NewTaskButton = styled.div`
-  cursor: pointer;
-  position: relative;
-  text-align: center;
-  color: white;
-  font-size: 1.6rem;
-  line-height: 2.9rem;
-  left: 40rem;
-  bottom: 5.5rem;
-  width: 3.1rem;
-  height: 3.1rem;
-  border-radius: 20rem;
-  background-color: var(--color-main);
-  box-shadow: 0px 0px 5px 3px rgba(175, 175, 175, 0.2);
-`;

--- a/client/src/components/MainContainer/MainContainer.tsx
+++ b/client/src/components/MainContainer/MainContainer.tsx
@@ -24,7 +24,6 @@ const MainContents = () => {
               element={
                 <>
                   <Log />
-                  <S.NewTaskButton onClick={() => setIsModalOpen(true)}>+</S.NewTaskButton>
                 </>
               }
             />

--- a/client/src/components/TaskModal/LabelInput.tsx
+++ b/client/src/components/TaskModal/LabelInput.tsx
@@ -269,6 +269,7 @@ const LabelListContainer = styled.div`
   display: flex;
   align-items: center;
   overflow-x: scroll;
+  overflow: overlay;
 `;
 
 const SelectedLabelListContainer = styled.div`

--- a/client/src/components/TaskModal/LabelInput.tsx
+++ b/client/src/components/TaskModal/LabelInput.tsx
@@ -270,6 +270,7 @@ const LabelListContainer = styled.div`
   align-items: center;
   overflow-x: scroll;
   overflow: overlay;
+  margin-top: 2px;
 `;
 
 const SelectedLabelListContainer = styled.div`
@@ -278,7 +279,8 @@ const SelectedLabelListContainer = styled.div`
   font-size: 0.8rem;
   display: flex;
   align-items: center;
-  overflow: scroll;
+  overflow-x: scroll;
+  overflow: overlay;
 `;
 
 const LabelListItem = styled.div<{ delete: boolean }>`

--- a/client/src/components/TaskModal/TaskModal.style.ts
+++ b/client/src/components/TaskModal/TaskModal.style.ts
@@ -43,7 +43,7 @@ export const FormTable = styled.table`
   }
 `;
 export const LagreTr = styled.tr`
-  height: 5.6rem;
+  height: 5.8rem;
 
   td:nth-child(1) {
     width: 4.5rem;

--- a/client/src/components/TopBar/Clock/Clock.style.ts
+++ b/client/src/components/TopBar/Clock/Clock.style.ts
@@ -4,5 +4,6 @@ export const DigitalClock = styled.span`
   color: white;
   font-size: 2.5rem;
   font-family: 'Baumans', cursive;
-  z-index: 1;
+  align-self: flex-end;
+  transform: translateY(0.3rem);
 `;

--- a/client/src/components/TopBar/Clock/Clock.tsx
+++ b/client/src/components/TopBar/Clock/Clock.tsx
@@ -31,11 +31,9 @@ const Clock = () => {
     };
   }, []);
   return (
-    <>
-      <S.DigitalClock>
-        {clockInfo.hour}:{clockInfo.minute}
-      </S.DigitalClock>
-    </>
+    <S.DigitalClock>
+      {clockInfo.hour}:{clockInfo.minute}
+    </S.DigitalClock>
   );
 };
 

--- a/client/src/components/TopBar/TopBar.style.ts
+++ b/client/src/components/TopBar/TopBar.style.ts
@@ -6,14 +6,19 @@ export const TopBarContainer = styled.div`
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  z-index: 999;
 `;
 
-export const MainTitle = styled.span`
+export const TopBarElement = styled.div<{ align: string }>`
+  width: 20rem;
+  display: flex;
+  justify-content: ${(props) => props.align};
+`;
+
+export const MainTitle = styled.div`
   color: white;
   font-size: 5.5rem;
   font-family: 'Baumans', cursive;
-  z-index: 1;
 `;
 
 export const MenuIcon = styled.img`

--- a/client/src/components/TopBar/TopBar.tsx
+++ b/client/src/components/TopBar/TopBar.tsx
@@ -7,13 +7,17 @@ interface TopBarProps {
 }
 const TopBar = ({ handleMenuClick }: TopBarProps) => {
   return (
-    <>
-      <S.TopBarContainer>
+    <S.TopBarContainer>
+      <S.TopBarElement align="left">
         <Clock />
+      </S.TopBarElement>
+      <S.TopBarElement align="center">
         <S.MainTitle>Boostart</S.MainTitle>
+      </S.TopBarElement>
+      <S.TopBarElement align="right">
         <S.MenuIcon src="/menu.svg" onClick={handleMenuClick} />
-      </S.TopBarContainer>
-    </>
+      </S.TopBarElement>
+    </S.TopBarContainer>
   );
 };
 

--- a/client/src/components/common/GlobalStyle.ts
+++ b/client/src/components/common/GlobalStyle.ts
@@ -1,9 +1,10 @@
 import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
-  body {
-    background: linear-gradient(var(--color-main) 55%, #ffffff 45%) fixed;
-    height: 100vh;
-    width: 100vw;
-  }
+  body{
+   background: linear-gradient(var(--color-main) 55%, #ffffff 45%) fixed;
+    width: 100%;
+    height: 100%;
+    }
+ 
 `;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,6 +5,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow: overlay;
 }
 
 code {
@@ -26,21 +27,20 @@ code {
 /* total width */
 *::-webkit-scrollbar {
   background-color: rgba(0, 0, 0, 0);
-  width: 16px;
-  height: 16px;
-  z-index: 800;
+  width: 8px;
+  height: 8px;
+  z-index: 999;
 }
 
 /* background of the scrollbar except button or resizer */
 *::-webkit-scrollbar-track {
-  background-color: rgba(0, 0, 0, 0);
+  background-color: none;
 }
 
 /* scrollbar itself */
 *::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0);
   border-radius: 16px;
-  border: 0px solid #fff;
 }
 
 /* set button(top and bottom of the scrollbar) */
@@ -50,12 +50,10 @@ code {
 
 /* scrollbar when element is hovered */
 *:hover::-webkit-scrollbar-thumb {
-  background-color: #a0a0a5;
-  border: 4px solid #fff;
+  background-color: rgba(174, 174, 174, 0.4);
 }
 
 /* scrollbar when scrollbar is hovered */
 *::-webkit-scrollbar-thumb:hover {
-  background-color: #a0a0a5;
-  border: 4px solid #f4f4f4;
+  background-color: rgba(174, 174, 174, 0.4);
 }

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -11,6 +11,7 @@ import Modal, { Dimmed } from '../components/common/Modal';
 import FriendSearchForm, { FRIEND_SEARCH_MODAL_ZINDEX } from '../components/FriendsBar/FriendSearchForm';
 import { DRAWER_Z_INDEX } from '../components/Drawer/Drawer.style';
 import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM } from '../constants';
+import styled from 'styled-components';
 
 const MainPage = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -58,23 +59,29 @@ const MainPage = () => {
 
   return (
     <RecoilRoot>
-      <TopBar handleMenuClick={() => setIsDrawerOpen(true)} />
-      <FriendsBar myProfile={myProfile} friendsList={friendsList} handlePlusButtonClick={() => setIsFriendSearchFormOpen(true)} />
-      <MainContents />
-      {isDrawerOpen && <Dimmed zIndex={DRAWER_Z_INDEX - 1} onClick={() => setIsDrawerOpen(false)} />}
-      <Drawer open={isDrawerOpen} />
-      {isFriendSearchFormOpen && (
-        <Modal
-          component={<FriendSearchForm selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} handleRequestButtonClick={() => sendFriendRequest()} />}
-          top={MODAL_CENTER_TOP}
-          left={MODAL_CENTER_LEFT}
-          transform={MODAL_CENTER_TRANSFORM}
-          zIndex={FRIEND_SEARCH_MODAL_ZINDEX}
-          handleDimmedClick={() => handleFriendSearchFormDimmedClick()}
-        />
-      )}
+      <Container>
+        <TopBar handleMenuClick={() => setIsDrawerOpen(true)} />
+        <FriendsBar myProfile={myProfile} friendsList={friendsList} handlePlusButtonClick={() => setIsFriendSearchFormOpen(true)} />
+        <MainContents />
+        {isDrawerOpen && <Dimmed zIndex={DRAWER_Z_INDEX - 1} onClick={() => setIsDrawerOpen(false)} />}
+        <Drawer open={isDrawerOpen} />
+        {isFriendSearchFormOpen && (
+          <Modal
+            component={<FriendSearchForm selectedFriend={selectedFriend} setSelectedFriend={setSelectedFriend} handleRequestButtonClick={() => sendFriendRequest()} />}
+            top={MODAL_CENTER_TOP}
+            left={MODAL_CENTER_LEFT}
+            transform={MODAL_CENTER_TRANSFORM}
+            zIndex={FRIEND_SEARCH_MODAL_ZINDEX}
+            handleDimmedClick={() => handleFriendSearchFormDimmedClick()}
+          />
+        )}
+      </Container>
     </RecoilRoot>
   );
 };
 
 export default MainPage;
+
+const Container = styled.div`
+  display: grid;
+`;


### PR DESCRIPTION
## 요약
- 전반적인 css 조정

## 작동 화면
![Nov-30-2022 17-46-24](https://user-images.githubusercontent.com/73420533/204749977-1714442a-9445-4c8f-9732-c3fb171b3616.gif)

## 작업 내용
1. 창 크기를 줄였을 때 화면이 잘리고 MainContents의 위치가 올바르지 않은 이슈 수정
2. TopBar의 space-between 속성이 각 요소의 width가 다름에 따라 한쪽에 치우치는 문제 수정
3. 불필요한 스크롤이 생기는 문제 수정
4. Log 컴포넌트 내 TimeBar UI 조정
5. #110 에서 추가한 스크롤 디자인 조정
6. 상위 내용을 포함하여 전체적인 css 크기 및 디자인 조정

## 관련 Task
- 22 창 크기가 줄어들었을 때 화면이 짤리는 이슈
- 36 스크롤바 스타일링

## 비고
- LOG, DIARY 타이틀이 해당 컴포넌트보다 뒤에 표시되는 이슈가 있습니다...
- LOG 컴포넌트 디자인은 LOG 추가 구현 진행하면서 따로 올리겠습니다!