### PR TITLE
[FE] [8-1] 목표 탭 기본 레이아웃 작업

### DIFF
--- a/client/src/components/MainContainer/GoalManager.style.ts
+++ b/client/src/components/MainContainer/GoalManager.style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const Goal = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  width: 40rem;
+  padding: 1rem;
+  border-radius: 20px;
+  background-color: #dddddd;
+  margin: 0.5rem auto;
+  * {
+    flex: 1;
+    text-align: center;
+  }
+`;
+
+export const GoalHead = styled(Goal)`
+  background-color: var(--color-main);
+`;

--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -1,10 +1,6 @@
 import SubContainer from './SubContainer';
 import * as S from './GoalManager.style';
 
-const GoalManagerWithContainer = () => {
-  return <SubContainer title="GOAL" element={<GoalManager />} />;
-};
-
 const GoalManager = () => {
   return (
     <>

--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -1,0 +1,118 @@
+import SubContainer from './SubContainer';
+import * as S from './GoalManager.style';
+
+const GoalManagerWithContainer = () => {
+  return <SubContainer title="GOAL" element={<GoalManager />} />;
+};
+
+const GoalManager = () => {
+  return (
+    <>
+      <S.GoalHead>
+        <span>목표</span> <span>제목</span> <span>현황</span> <span>달성률</span>
+      </S.GoalHead>
+      {dummyGoals.map((goal) => (
+        <Goal key={goal.idx} goal={goal} />
+      ))}
+    </>
+  );
+};
+
+const dummyGoals = [
+  {
+    idx: 1,
+    title: '커피 줄이기',
+    labelIdx: 1,
+    goalAmount: 2,
+    currentAmount: 4,
+    over: false,
+  },
+  {
+    idx: 2,
+    title: '잠좀자기',
+    labelIdx: 3,
+    goalAmount: 480,
+    currentAmount: 300,
+    over: true,
+  },
+  {
+    idx: 3,
+    title: '절약',
+    labelIdx: 2,
+    goalAmount: 20000,
+    currentAmount: 12000,
+    over: false,
+  },
+];
+
+interface Label {
+  color: string;
+  title: string;
+  unit: string;
+}
+
+const dummyLabels: Label[] = [
+  {
+    title: '커피',
+    color: '#222222',
+    unit: '잔',
+  },
+  {
+    title: '커피',
+    color: '#222222',
+    unit: '잔',
+  },
+  {
+    title: '지출',
+    color: '#442222',
+    unit: '원',
+  },
+  {
+    title: '잠',
+    color: '#225522',
+    unit: '분',
+  },
+];
+
+interface Goal {
+  idx: number;
+  title: string;
+  labelIdx: number;
+  goalAmount: number;
+  currentAmount: number;
+  over: boolean;
+}
+
+interface GoalProps {
+  goal: Goal;
+}
+
+const Goal = ({ goal }: GoalProps) => {
+  const { idx, title, labelIdx, currentAmount, goalAmount, over } = goal;
+  const { title: labelTitle, color: labelColor, unit: labelUnit } = dummyLabels[labelIdx];
+
+  const formatRate = (rate: number) => {
+    return (100 * rate).toFixed(0).toString() + '%';
+  };
+
+  const rate = over ? formatRate(Math.min(currentAmount / goalAmount, 1)) : currentAmount <= goalAmount ? 'success' : 'failed';
+
+  return (
+    <S.Goal>
+      <span>
+        {labelTitle}
+        {goalAmount}
+        {labelUnit}
+        {over ? '▲' : '▼'}
+      </span>
+      <span>{title}</span>{' '}
+      <span>
+        {currentAmount}
+        {labelUnit}
+      </span>
+      <span>{rate}</span>
+    </S.Goal>
+  );
+};
+
+export default GoalManagerWithContainer;

--- a/client/src/components/MainContainer/MainContainer.tsx
+++ b/client/src/components/MainContainer/MainContainer.tsx
@@ -4,6 +4,7 @@ import Modal from '../common/Modal';
 import TaskModal from '../TaskModal/TaskModal';
 import Calendar from './Calendar';
 import Diary from './Diary';
+import GoalManagerWithContainer from './GoalManager';
 import Log from './Log';
 import * as S from './MainContainer.style';
 
@@ -29,6 +30,7 @@ const MainContents = () => {
               }
             />
             <Route path="diary/" element={<Diary />} />
+            <Route path="goal" element={<GoalManagerWithContainer />} />
           </Routes>
         </S.RightSection>
       </S.MainContentContainer>

--- a/client/src/components/MainContainer/MainContainer.tsx
+++ b/client/src/components/MainContainer/MainContainer.tsx
@@ -4,9 +4,10 @@ import Modal from '../common/Modal';
 import TaskModal from '../TaskModal/TaskModal';
 import Calendar from './Calendar';
 import Diary from './Diary';
-import GoalManagerWithContainer from './GoalManager';
+import GoalManager from './GoalManager';
 import Log from './Log';
 import * as S from './MainContainer.style';
+import SubContainer from './SubContainer';
 
 const MainContents = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -30,7 +31,7 @@ const MainContents = () => {
               }
             />
             <Route path="diary/" element={<Diary />} />
-            <Route path="goal" element={<GoalManagerWithContainer />} />
+            <Route path="goal" element={<SubContainer title="GOAL" element={<GoalManager />} />} />
           </Routes>
         </S.RightSection>
       </S.MainContentContainer>

--- a/client/src/components/MainContainer/SubContainer.style.ts
+++ b/client/src/components/MainContainer/SubContainer.style.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const Content = styled.div`
+  width: 100%;
+  height: 36rem;
+  background: white;
+  border-radius: 1rem;
+  margin-top: 0rem;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  position: relative;
+  box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
+  user-select: none;
+`;
+
+export const Title = styled.span`
+  display: inline-block;
+  color: white;
+  font-size: 1.7rem;
+  font-family: 'Press Start 2P', cursive;
+  transform: translate(1.75rem, 0.43rem);
+  z-index: 1;
+`;
+
+export const NavBarSection = styled.div`
+  width: 100%;
+  height: 3rem;
+  padding-bottom: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  grid-area: nav;
+  box-sizing: border-box;
+  cursor: default;
+`;

--- a/client/src/components/MainContainer/SubContainer.tsx
+++ b/client/src/components/MainContainer/SubContainer.tsx
@@ -1,0 +1,23 @@
+import DateSelector from './DateSelector';
+import * as S from './SubContainer.style';
+
+interface SubContainerProps {
+  title: string;
+  element: JSX.Element;
+}
+
+const SubContainer = ({ title, element }: SubContainerProps) => {
+  return (
+    <>
+      <S.Title>{title}</S.Title>
+      <S.Content>
+        <S.NavBarSection>
+          <DateSelector />
+        </S.NavBarSection>
+        {element}
+      </S.Content>
+    </>
+  );
+};
+
+export default SubContainer;

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -23,7 +23,7 @@ export enum Days {
   '금',
   '토',
 }
-export const Menus = ['LOG', 'DIARY', 'PLAN', 'MAP'];
+export const Menus = ['LOG', 'DIARY', 'GOAL', 'MAP'];
 
 export const WEEK_LENGTH = Object.keys(Days).length / 2;
 interface RoutePathType {
@@ -36,6 +36,7 @@ export const RoutePath: RoutePathType = {
   MAIN: '/main/*',
   LOG: '/main/log',
   DIARY: '/main/diary',
+  GOAL: '/main/goal',
 };
 
 export const MODAL_CENTER_TOP = '50%';


### PR DESCRIPTION
## 요약
목표 탭을 추가했습니다.

## 작동 화면
![image](https://user-images.githubusercontent.com/55306894/204790022-a4518992-6a23-4c97-a19f-0e4900e938fd.png)

## 작업 내용
1. 공통 레이아웃에 쓸 `SubContainer` 컴포넌트 작성
2. 목표 탭에 맞게 이름을 수정했습니다.
   - `PLAN` → `GOAL`
3. `GoalManager` 컴포넌트 작성
   - 더미 데이터를 가지고 만들었으며, 더미 데이터는 6가지 필드로 이루어져 있습니다.
     - `idx`, `title`,  `labelIdx`, `goalAmount`, `currentAmount`, `over`
   - `labelIdx`를 통해 라벨 이름이나 단위를 알아내야 하므로 클라이언트는 label 목록을 미리 알고 있어야 합니다.
   - 목표 세부 달성률은 클라이언트 단에서 계산합니다.

## 테스트 방법
1. 로그인을 완료하세요.
2. GOAL 탭을 누르세요.
