### PR TITLE
[FE] [39] 태스크 생성 모달에서 위치를 반드시 지정해야 하는 문제 해결

### DIFF
--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -47,8 +47,14 @@ const TaskModal = ({ handleCloseButtonClick, fetchTaskList }: Props) => {
     importance: yup.number().required(),
     isPublic: yup.bool(),
     location: yup.string(),
-    lat: yup.number(),
-    lng: yup.number(),
+    lat: yup
+      .number()
+      .transform((value) => (isNaN(value) ? undefined : value))
+      .nullable(),
+    lng: yup
+      .number()
+      .transform((value) => (isNaN(value) ? undefined : value))
+      .nullable(),
     content: yup.string(),
   });
   const {
@@ -72,7 +78,6 @@ const TaskModal = ({ handleCloseButtonClick, fetchTaskList }: Props) => {
   };
 
   const createTask = async (body: FieldValues) => {
-    console.log(JSON.stringify(body).split(',').join('\n'));
     await httpPostTask({ ...body, date: formatDate(currentDate) });
     await fetchTaskList();
     handleCloseButtonClick();


### PR DESCRIPTION
## 요약
`yupResolver`의 스키마를 수정했습니다.

## 테스트 방법
1. 로그인을 완료하세요
2. 태스크 생성 모달을 여세요.
3. 기본 필드 작성을 완료하세요.
4. 더보기 버튼을 누르세요.
5. `NEW TASK!` 버튼을 누르세요


## 비고
### 원인
1. `string` 타입 input 기본값은 `""`입니다.
2. `number` 타입 input 기본값은 `NaN`입니다.
3. `yup.number()`는 `NaN`을 숫자로 인식하지 않습니다.
  → 유효성 검증에서 실패합니다.
### 해결책
1. `NaN`을 직접 `undefined`로 캐스팅합니다.