### PR TITLE
[BE] [7-10] 태스크 수정 API 구현

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -207,17 +207,14 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 });
 
 router.put('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
-  if (req.body.date != undefined) return res.status(409).send({ msg: '날짜는 수정할 수 없어요.' });
-  if (req.body.done != undefined) return res.status(409).send({ msg: '완료 상태를 수정할 수 없어요.' });
-
   const bodyKeysCount = Object.keys(req.body).length;
   if (bodyKeysCount === 0) return res.status(200).send({ msg: '수정할 사항이 없어요.' });
 
   const { userIdx } = req.user;
   const { task_idx: taskIdx } = req.params;
-  const { labels } = req.body;
+  const { date, done, labels } = req.body;
 
-  const willUpdateTask = bodyKeysCount > 1 || (bodyKeysCount === 1 && !labels);
+  const willUpdateTask = bodyKeysCount > 1 || (bodyKeysCount === 1 && !date && done === undefined && !labels);
 
   let updateSql = 'update task set';
   const updateValue = [];
@@ -225,6 +222,7 @@ router.put('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) 
   try {
     Object.values(TaskBodyKeys).forEach((key) => {
       if (!req.body[key]) return;
+      if (key === TaskBodyKeys.date || key === TaskBodyKeys.done) return;
       if (!validate(key, req.body[key])) req.body[key] = TaskBodyDefaultValues[key];
 
       if (key === TaskBodyKeys.labels) return;

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -206,7 +206,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
-router.put('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
   const bodyKeysCount = Object.keys(req.body).length;
   if (bodyKeysCount === 0) return res.status(200).send({ msg: '수정할 사항이 없어요.' });
 

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -207,6 +207,9 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 });
 
 router.put('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  if (req.body.date != undefined) return res.status(409).send({ msg: '날짜는 수정할 수 없어요.' });
+  if (req.body.done != undefined) return res.status(409).send({ msg: '완료 상태를 수정할 수 없어요.' });
+
   const bodyKeysCount = Object.keys(req.body).length;
   if (bodyKeysCount === 0) return res.status(200).send({ msg: '수정할 사항이 없어요.' });
 


### PR DESCRIPTION
## 요약
태스크를 수정할 수 있는 API를 구현하였습니다.
태스크의 `date`, `done`은 수정이 불가능합니다.
해당 API를 통해 `date`, `done`에 대해 수정 요청을 하더라도 수정되지 않고 기존의 값이 유지됩니다.
`done`의 경우 태스크 일부 수정 API(`PATCH`) 요청을 통해 수정할 수 있습니다.
### _**태스크 수정 API 요청 시 Request Body에는 수정하고 싶은 값만 입력하시면 됩니다.**_
수정하고 싶지 않은 값을 `null`로 설정하게 되면 해당 값이 `null`로 수정됩니다.

`labels` 입력은 다음과 같이 처리됩니다.
- `labels` 입력하지 않음 : `labels` 수정하지 않음
- `labels: undefined`로 입력 : `labels` 수정하지 않음
- `labels: []`로 입력 : 모든 `labels` 삭제
- `labels: [{ 새로운 라벨 정보 }]` : 새로운 라벨 정보로 갱신됨
   - 내부에서는 새로운 라벨 정보와 기존의 라벨 정보를 비교하여 아래와 같은 동작을 수행합니다.
      - 기존에 존재하던 라벨 정보 → 값이 바뀌었다면 수정, 아니면 두기
      - 기존에 존재하던 라벨 정보가 새로운 라벨 정보에 없음 → 기존 라벨 정보 삭제
      - 새로운 라벨이 추가됨 → 라벨 정보 추가

위의 사항을 참고하셔서 API 사용해주시면 될 것 같습니다.

- 요청 URL : `/task/:task_idx`
   - `Request Body` : `{ title, importance, date, startedAt, endedAt, lat, lng, location, isPublic, tagIdx, content, done, labels: [ { labelIdx,  amount } ] }` (수정하고 싶은 값만 입력)
   - method : `PATCH`
- 응답
   - 태스크 수정 성공 : `200`
   - 유효하지 않은 입력 : `400`
   - 존재하지 않는 태스크 및 라벨 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 태스크 수정 요청
1. `/task?date=2022-11-29`를 통해 태스크 목록 확인
2. `idx = 23` 태스크에 대해 수정 내용이 없는 수정 요청
3. `/task?date=2022-11-29`를 통해 수정된 사항이 없음을 확인
4. `idx = 23` 태스크에 대해 `title` 수정 요청
5. `/task?date=2022-11-29`를 통해 `title`이 수정되었음을 확인
6. `idx = 23` 태스크에 대해 `labels: []` 수정 요청
7. `/task?date=2022-11-29`를 통해 `labels`이 빈 배열로 수정되었음을 확인
8. `idx = 23` 태스크에 대해 `labels` 수정 요청
9. `/task?date=2022-11-29`를 통해 `labels`이 입력한 라벨 정보로 수정되었음을 확인

[92aacab1-ac7f-44ab-8d46-fd7b918991be.webm](https://user-images.githubusercontent.com/92143119/204883917-4a3496fa-161c-4060-b47a-6a463e908a39.webm)
### 존재하지 않는 태스크에 대한 요청, 유효하지 않은 입력 처리
1. 존재하지 않는 `idx = 230` 태스크에 대한 수정 요청
2. `404` 코드가 반환되는 것을 확인
3. `title`의 값을 `number` 타입의 값으로 수정 요청
4. `400` 코드가 반환되는 것을 확인

[dcdf5a2f-6a0e-4ca6-b0ad-6807883e7a62.webm](https://user-images.githubusercontent.com/92143119/204884591-6d0ee605-009f-4358-a6a0-957d243814f0.webm)
### `date`에 대한 수정 요청
1. `/task?date=2022-12-01`을 통해 태스크 목록 확인
2. `idx = 23` 태스크에 대해 `date` 수정 요청
3. `/task?date=2022-12-01`을 통해 변경된 내용이 없음을 확인

[39bbfa97-878e-4d7f-b4d3-75da28a3dcd8.webm](https://user-images.githubusercontent.com/92143119/204884955-f6373198-8d6a-47e2-a936-92e0b952b062.webm)

## 작업 내용
1. 태스크 수정 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
11. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/task/${task_idx}', {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       ${수정하고 싶은 항목}: ${수정할 값}
     }),
   });
   ```

## 관련 Task
- [7-10]