### PR TITLE
[FE] [41] 목표 탭 export 변수명이 잘못되어있던 점 수정

### DIFF
--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -111,4 +111,4 @@ const Goal = ({ goal }: GoalProps) => {
   );
 };
 
-export default GoalManagerWithContainer;
+export default GoalManager;


### PR DESCRIPTION
## 요약
`export GoalManagerWithContainer` → `export GoalManager`
