### PR TITLE
[FE] [42] useCurrentDate 훅 dateToString 메소드 추가

### DIFF
--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -13,7 +13,6 @@ const Diary = () => {
 
   useEffect(() => {
     const currentDateString = dateToString();
-    console.log(currentDateString);
     globalSocket.emit('joinToNewRoom', currentVisit, currentDateString);
     globalSocket.emit('requestCurrentObjects');
     return () => {

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { visitState } from '../common/atoms';
 import globalSocket from '../common/Socket';
@@ -9,13 +9,11 @@ import useCurrentDate from '../../hooks/useCurrentDate';
 
 const Diary = () => {
   const currentVisit = useRecoilValue(visitState);
-  const { currentDate, getYear, getMonth, getDate } = useCurrentDate();
-  const createDateString = () => {
-    return `${getYear()}${(getMonth() + 1).toString().padStart(2, '0')}${getDate().toString().padStart(2, '0')}`;
-  };
+  const { currentDate, DateToString } = useCurrentDate();
 
   useEffect(() => {
-    const currentDateString = createDateString();
+    const currentDateString = DateToString();
+    console.log(currentDateString);
     globalSocket.emit('joinToNewRoom', currentVisit, currentDateString);
     globalSocket.emit('requestCurrentObjects');
     return () => {

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -9,10 +9,10 @@ import useCurrentDate from '../../hooks/useCurrentDate';
 
 const Diary = () => {
   const currentVisit = useRecoilValue(visitState);
-  const { currentDate, DateToString } = useCurrentDate();
+  const { currentDate, dateToString } = useCurrentDate();
 
   useEffect(() => {
-    const currentDateString = DateToString();
+    const currentDateString = dateToString();
     console.log(currentDateString);
     globalSocket.emit('joinToNewRoom', currentVisit, currentDateString);
     globalSocket.emit('requestCurrentObjects');

--- a/client/src/hooks/useCurrentDate.ts
+++ b/client/src/hooks/useCurrentDate.ts
@@ -46,6 +46,9 @@ const useCurrentDate = () => {
   const getDate = () => {
     return currentDate.getDate();
   };
+  const DateToString = (date: Date = currentDate) => {
+    return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+  };
 
   return {
     currentDate,
@@ -59,6 +62,7 @@ const useCurrentDate = () => {
     getMonth,
     getYear,
     getDate,
+    DateToString,
   };
 };
 export default useCurrentDate;

--- a/client/src/hooks/useCurrentDate.ts
+++ b/client/src/hooks/useCurrentDate.ts
@@ -46,7 +46,7 @@ const useCurrentDate = () => {
   const getDate = () => {
     return currentDate.getDate();
   };
-  const DateToString = (date: Date = currentDate) => {
+  const dateToString = (date: Date = currentDate) => {
     return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
   };
 
@@ -62,7 +62,7 @@ const useCurrentDate = () => {
     getMonth,
     getYear,
     getDate,
-    DateToString,
+    dateToString,
   };
 };
 export default useCurrentDate;


### PR DESCRIPTION
## 요약
useCurrentDate 훅에 날짜를 'YYYY-MM-DD'형식의 string으로 변환해주는 메소드를 추가했습니다

## 작동 화면
없다면 생략

## 작업 내용
1. useCurrentDate 훅에 날짜를 'YYYY-MM-DD'형식의 string으로 변환해주는 메소드를 추가했습니다
2. parameter(Date type)를 입력해줄경우 해당날짜를 변환시켜주며 아무값도 넘겨주지 않을 경우 currentDate에서 관리되는 recoil state 기준으로 값이 반환됩니다.

## 테스트 방법
1.

## 관련 Task
-[42]

## 비고
return 형식= 'YYYY-MM-DD'