### PR TITLE
[BE] [7-31] 태스크 삭제 API 구현

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -354,4 +354,20 @@ router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res
   }
 });
 
+router.delete('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const { task_idx: taskIdx } = req.params;
+
+  try {
+    const notExistTask = ((await executeSql('select idx from task where user_idx = ? and idx = ?', [userIdx, taskIdx])) as RowDataPacket).length === 0;
+    if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 태스크예요.' });
+
+    await executeSql('delete from task_label where task_idx = ?', [taskIdx]);
+    await executeSql('delete from task where user_idx = ? and idx = ?', [userIdx, taskIdx]);
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(500);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## 요약
태스크를 삭제하는 API를 구현하였습니다.
- 요청 URL : `/task/:task_idx`
   - `task_idx` : 삭제하고 싶은 태스크
   - method : `DELETE`
- 응답
   - 태스크 삭제 성공 : `200`
   - 존재하지 않는 태스크 : `404` (자신의 태스크 내에서 해당 태스크를 찾기 때문에 다른 사람의 태스크를 입력한 경우도 해당)
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 존재하지 않는 태스크에 대한 요청, 태스크 삭제 요청
1. `/task?date=2022-12-20`을 통해 태스크 목록 확인
2. 존재하지 않는 `idx = 270` 태스크에 대한 삭제 요청
3. `404` 코드가 반환되는 것을 확인
4. `idx = 27` 태스크에 대한 삭제 요청
5. `/task?date=2022-12-20`을 통해 해당 태스크가 삭제되었음을 확인

[7dbf79f4-01c1-4605-9521-9146cec2a853.webm](https://user-images.githubusercontent.com/92143119/204970349-827d0be9-415a-4384-bc05-5250dca33cec.webm)

## 작업 내용
1. 태스크 삭제 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
6. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/task/${task_idx}', {
     method: 'delete',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
   });
   ```

## 관련 Task
- [7-31]