### PR TITLE
[BE] [34] 회원가입 시 기본 프로필 이미지 설정 구현

### DIFF
--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { CLIENT, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URI, OAUTH_TYPES, TOKEN_SECRET } from '../constants';
+import { CLIENT, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URI, OAUTH_TYPES, TOKEN_SECRET, DEFAULT_PROFILE } from '../constants';
 import axios from 'axios';
 import qs from 'qs';
 import { authenticateToken, generateAccessToken } from '../utils/auth';
@@ -129,7 +129,8 @@ router.get('/login/:oauth_type/callback', async (req, res) => {
 router.post('/signup', async (req: SignupRequest, res) => {
   const { userId, password, username } = req.body;
   let profileImgFilename = '';
-  if (req.files) {
+  if (!req.files) profileImgFilename = DEFAULT_PROFILE;
+  else {
     const { profileImg } = req.files;
     profileImgFilename = profileImg.name; // TODO: 해시하기
     profileImg.mv('./uploads/' + profileImgFilename);

--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -19,3 +19,4 @@ export const OAUTH_TYPES = {
   github: 'github',
 } as const;
 export const HOST = process.env.MODE === 'dev' ? process.env.DEV_HOST : process.env.PROD_HOST;
+export const DEFAULT_PROFILE = 'default_profile.png';


### PR DESCRIPTION
## 요약
회원가입 시 프로필 이미지를 설정하지 않았다면 기본 프로필 이미지를 설정하도록 구현하였습니다.
추가로 기존에 DB에 존재하던 user 데이터 중 프로필 이미지가 null인 데이터의 프로필 이미지 또한 기본 프로필 이미지로 설정하였습니다.

## 작동 화면
1. 프로필 이미지를 설정하지 않은 채로 회원가입
2. 회원가입한 계정으로 로그인
3. `/user/me`를 통해 프로필 이미지가 `default_profile.png`로 설정되었음을 확인

[c87a78ad-40ae-44c4-9239-8921512d7f39.webm](https://user-images.githubusercontent.com/92143119/204989532-659eaa66-7035-48cf-9b91-a35d52a63f0d.webm)


## 작업 내용
1. 기본 프로필 이미지 파일을 상수로 지정
4. 프로필 이미지를 설정하지 않은 경우 기본 프로필 이미지로 설정

## 테스트 방법
1. 프로필 이미지를 설정하지 않은 채로 회원가입을 완료합니다.
5. 회원가입 한 계정으로 로그인을 완료합니다.
6. `/user/me`를 통해 프로필 정보를 확인합니다.

## 관련 Task
- [34]

## 비고
아직 파일명만 설정해 놓은 상태이고 기본 프로필 이미지 파일은 구하지 못했습니다.
구하는 대로 슬랙에 공유 드리겠습니다.