### PR TITLE
[BE] [45] 태스크 수정 API, 태스크 부분 수정 API 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -344,7 +344,7 @@ router.patch('/status/:task_idx', authenticateToken, async (req: AuthorizedReque
       status = 206;
     }
 
-    if (done) {
+    if (done != undefined) {
       if (task.done === done) return res.sendStatus(status);
       await executeSql('update task set done = ? where idx = ?', [done, taskIdx]);
     }

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -344,7 +344,7 @@ router.patch('/status/:task_idx', authenticateToken, async (req: AuthorizedReque
       status = 206;
     }
 
-    if (done != undefined) {
+    if (done !== undefined) {
       if (task.done === done) return res.sendStatus(status);
       await executeSql('update task set done = ? where idx = ?', [done, taskIdx]);
     }

--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -242,7 +242,7 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
-router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+router.patch('/update/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
   const bodyKeysCount = Object.keys(req.body).length;
   if (bodyKeysCount === 0) return res.status(200).send({ msg: '수정할 사항이 없어요.' });
 
@@ -323,7 +323,7 @@ router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res
   }
 });
 
-router.patch('/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+router.patch('/status/:task_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   const taskIdx = req.params.task_idx;
   const { done, tagIdx } = req.body;


### PR DESCRIPTION
## 요약
태스크 수정 API와 태스크 부분 수정 API가 구분되지 않았던 문제를 해결하기 위해 두 API의 요청 URL을 변경하였습니다.
추가로 태스크 부분 수정 API에서 `done`을 `false`로 변경하는 요청이 동작하지 않는 문제를 해결하였습니다.
`done`에 대한 수정을 요청하고 있는지 판별하는 부분에서 `if (done)` 조건문을 사용하여 `done`이 `false`일 때에도 해당 조건문 내의 명령이 수행되지 않아 발생한 문제였습니다.
조건문을 `if (done !== undefined)`로 수정하여 해결하였습니다.
### API 요청 URL 변경 사항
- 태스크 수정 API
   - 요청 URL : `/task/update/:task_idx`
   - method : `PATCH`
- 태스크 부분 수정 API
   - 요청 URL : `/task/status/:task_idx`
   - method : `PATCH`

API 문서에도 해당 사항을 반영해 놓았습니다.

## 작동 화면
1. `/task?date=2022-12-01`을 통해 태스크 목록을 확인합니다.
2. `/task/update/14`를 통해 `idx = 14` 태스크에 대해 `title` 수정 요청을 전송합니다.
3. `/task?date=2022-12-01`을 통해 수정이 정상적으로 이루어졌음을 확인합니다.
4. `/task/status/14`를 통해 `idx = 14` 태스크에 대해 `done = false` 부분 수정 요청을 전송합니다.
5. `/task?date=2022-12-01`을 통해 수정이 정상적으로 이루어졌음을 확인합니다.

[6c64b468-8684-44ef-a2d0-e1dd82819d39.webm](https://user-images.githubusercontent.com/92143119/204992308-aff90d64-7ca4-4d16-b6da-dad4cab173ac.webm)

## 작업 내용
1. 태스크 수정 API 및 태스크 부분 수정 API URL 수정
5. 태스크 부분 수정 시 `done = false` 요청이 동작하도록 수정

## 테스트 방법
### 태스크 수정 API
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/task/update/${task_idx}', {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       ${수정하고 싶은 항목}: ${수정할 값}
     }),
   });
   ```
### 태스크 부분 수정 API
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/task/status/${task_idx}', {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       ${수정하고 싶은 항목}: ${수정할 값}
     }),
   });
   ```
## 관련 Task
- [45]