### PR TITLE
[BE] [4-4] 프로필 수정 API 구현

### DIFF
--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -3,6 +3,7 @@ import { RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
+import { DEFAULT_PROFILE } from '../constants';
 
 const router = Router();
 
@@ -22,6 +23,19 @@ router.get('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
   try {
     const [userInfo] = (await executeSql('select user_id as userId, username, profile_img as profileImg from user where idx = ?', [userIdx])) as RowDataPacket[];
     res.json(userInfo);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+router.patch('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  let { username, profileImg } = req.body;
+  if (!username || profileImg === undefined) return res.status(400).json({ msg: '올바른 정보를 입력해주세요.' });
+  if (!profileImg) profileImg = DEFAULT_PROFILE;
+  try {
+    await executeSql('update user set username = ?, profile_img = ? where idx = ?', [username, profileImg, userIdx]);
+    res.sendStatus(200);
   } catch {
     res.sendStatus(500);
   }


### PR DESCRIPTION
## 요약
프로필을 수정하는 API를 구현하였습니다.
프로필 수정 시 `username`과 `profileImg`만 수정 가능합니다.
- 요청 URL : `/user/me`
   - `Request Body` : `{ username, profileImg }`
   - method : `PATCH`
- 응답
   - 프로필 수정 성공 : `200`
   - `username`과 `profileImg`를 입력하지 않은 경우 : `400` (`profileImg: null`로 입력한 경우 회원가입 시와 마찬가지로 기본 프로필 이미지가 설정됨)
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/user/me`를 통해 프로필 확인
2. `profileImg`를 입력하지 않은 수정 요청
3. `400` 코드가 반환되는 것을 확인
4. `profileImg`를 `null`로 설정한 수정 요청
5. `/user/me`를 통해 수정이 정상적으로 이루어졌으며 `profileImg`의 경우 기본 프로필 이미지 파일로 설정된 것을 확인

[c10f2b48-fca0-44cd-a97e-4f047693ecd3.webm](https://user-images.githubusercontent.com/92143119/205063121-4f62cd63-9b21-4db9-8138-a06717d7d18e.webm)


## 작업 내용
1. 프로필 수정 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
6. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/user/me', {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       username: ${username},
       profileImg: ${profileImg},
     }),
   });
   ```

## 관련 Task
- [4-4]