### PR TITLE
[FE] [49] 로그 컴포넌트 - API URI 최신화

### DIFF
--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -140,7 +140,7 @@ const Log = () => {
 
     if (sourceTagIndex !== destinationTagIndex) {
       try {
-        await axios.patch(`${HOST}/api/v1/task/${taskIdx}`, { tagIdx: destinationTagIndex });
+        await axios.patch(`${HOST}/api/v1/task/status/${taskIdx}`, { tagIdx: destinationTagIndex });
         await fetchTaskList();
       } catch (error) {
         selectedTaskRef.current.style.visibility = 'visible';


### PR DESCRIPTION
## 요약
API URI를 최신 상태로 변경했습니다

## 비고
현재 태스크 옮기기가 작동하지 않으며, 이 PR이 머지된 후 고쳐집니다.
