### PR TITLE
[FE] [57] 태스크 모달 버그 수정

### DIFF
--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -221,14 +221,7 @@ const Log = () => {
           </S.LogMainSection>
           <S.NewTaskButton onClick={() => setIsModalOpen(true)} />
           {isModalOpen && (
-            <Modal
-              component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} fetchTaskList={fetchTaskList} tagList={tagList} fetchTagList={fetchTagList} />}
-              zIndex={1001}
-              top="50%"
-              left="50%"
-              transform="translate(-50%, -50%)"
-              handleDimmedClick={() => {}}
-            />
+            <Modal component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} tagList={tagList} fetchTagList={fetchTagList} />} zIndex={1001} top="50%" left="50%" transform="translate(-50%, -50%)" handleDimmedClick={() => {}} />
           )}
         </S.LogContainer>
       </S.Container>

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -220,7 +220,16 @@ const Log = () => {
             <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
           </S.LogMainSection>
           <S.NewTaskButton onClick={() => setIsModalOpen(true)} />
-          {isModalOpen && <Modal component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} fetchTaskList={fetchTaskList} />} zIndex={1001} top="50%" left="50%" transform="translate(-50%, -50%)" handleDimmedClick={() => {}} />}
+          {isModalOpen && (
+            <Modal
+              component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} fetchTaskList={fetchTaskList} tagList={tagList} fetchTagList={fetchTagList} />}
+              zIndex={1001}
+              top="50%"
+              left="50%"
+              transform="translate(-50%, -50%)"
+              handleDimmedClick={() => {}}
+            />
+          )}
         </S.LogContainer>
       </S.Container>
     </>

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -9,7 +9,7 @@ import { Tag } from 'GlobalType';
 axios.defaults.withCredentials = true; // withCredentials 전역 설정
 
 interface TagInputProps {
-  tag?: Tag;
+  tagIdx: number | null;
   setTagIdx: React.Dispatch<number | null>;
   tagList: Tag[];
   fetchTagList: () => Promise<void>;
@@ -17,12 +17,13 @@ interface TagInputProps {
   setShowSearchedTagList: React.Dispatch<boolean>;
 }
 
-const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, showSearchedTagList, setShowSearchedTagList }: TagInputProps) => {
+const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagList, setShowSearchedTagList }: TagInputProps) => {
   const [tagInput, onChangeTagInput, setTagInput] = useInput('');
   const [searchedTagList, setSearchedTagList] = useState<Tag[]>([]);
   const [newTagColor, setNewTagColor] = useState('');
 
-  const { idx: tagIdx, title } = tag ?? {};
+  const tag = tagList.find((tag) => tag.idx === tagIdx);
+  const title = tag?.title;
   const [color, setColor] = useState<string | undefined>(tag?.color);
 
   //태그 선택 해제

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -13,11 +13,11 @@ interface TagInputProps {
   setTagIdx: React.Dispatch<number | null>;
   tagList: Tag[];
   fetchTagList: () => Promise<void>;
-  showSearchedTagList: boolean;
-  setShowSearchedTagList: React.Dispatch<boolean>;
+  isTagInputFocused: boolean;
+  setIsTagInputFocused: React.Dispatch<boolean>;
 }
 
-const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagList, setShowSearchedTagList }: TagInputProps) => {
+const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, isTagInputFocused, setIsTagInputFocused }: TagInputProps) => {
   const [tagInput, onChangeTagInput, setTagInput] = useInput('');
   const [searchedTagList, setSearchedTagList] = useState<Tag[]>([]);
   const [newTagColor, setNewTagColor] = useState('');
@@ -33,7 +33,7 @@ const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagLis
   };
 
   const handleWindowClick = () => {
-    setShowSearchedTagList(false);
+    setIsTagInputFocused(false);
   };
 
   useEffect(() => {
@@ -53,7 +53,7 @@ const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagLis
   //하나의 태그 선택
   const setTagItem = (idx: number) => () => {
     setTagIdx(idx);
-    setShowSearchedTagList(false);
+    setIsTagInputFocused(false);
   };
 
   const postNewTag = async () => {
@@ -129,13 +129,13 @@ const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagLis
 
   const handleTagInputClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setShowSearchedTagList(true);
+    setIsTagInputFocused(true);
   };
 
   return !tagIdx ? (
     <TagContainer>
-      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} autoFocus={showSearchedTagList} onFocus={() => setShowSearchedTagList(true)} />
-      {showSearchedTagList && <SearchedTagList />}
+      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} autoFocus={isTagInputFocused} onFocus={() => setIsTagInputFocused(true)} />
+      {isTagInputFocused && <SearchedTagList />}
     </TagContainer>
   ) : (
     <TagContainer>

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -18,7 +18,6 @@ interface TagInputProps {
 }
 
 const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, isTagInputFocused, setIsTagInputFocused }: TagInputProps) => {
-  // const [isTagInputFocused, setIsTagInputFocused] = useState(false);
   const [tagInput, onChangeTagInput, setTagInput] = useInput('');
   const [searchedTagList, setSearchedTagList] = useState<Tag[]>([]);
   const [newTagColor, setNewTagColor] = useState('');

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -13,11 +13,11 @@ interface TagInputProps {
   setTagIdx: React.Dispatch<number | null>;
   tagList: Tag[];
   fetchTagList: () => Promise<void>;
-  isTagInputFocused: boolean;
-  setIsTagInputFocused: React.Dispatch<boolean>;
+  showSearchedTagList: boolean;
+  setShowSearchedTagList: React.Dispatch<boolean>;
 }
 
-const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, isTagInputFocused, setIsTagInputFocused }: TagInputProps) => {
+const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, showSearchedTagList, setShowSearchedTagList }: TagInputProps) => {
   const [tagInput, onChangeTagInput, setTagInput] = useInput('');
   const [searchedTagList, setSearchedTagList] = useState<Tag[]>([]);
   const [newTagColor, setNewTagColor] = useState('');
@@ -32,7 +32,7 @@ const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, isTagInputFocused, se
   };
 
   const handleWindowClick = () => {
-    setIsTagInputFocused(false);
+    setShowSearchedTagList(false);
   };
 
   useEffect(() => {
@@ -127,13 +127,13 @@ const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, isTagInputFocused, se
 
   const handleTagInputClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsTagInputFocused(true);
+    setShowSearchedTagList(true);
   };
 
   return !tagIdx ? (
     <TagContainer>
-      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} autoFocus={isTagInputFocused} onFocus={() => setIsTagInputFocused(true)} />
-      {isTagInputFocused && <SearchedTagList />}
+      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} autoFocus={showSearchedTagList} onFocus={() => setShowSearchedTagList(true)} />
+      {showSearchedTagList && <SearchedTagList />}
     </TagContainer>
   ) : (
     <TagContainer>

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -133,7 +133,7 @@ const TagInput = ({ tag, setTagIdx, tagList, fetchTagList, isTagInputFocused, se
 
   return !tagIdx ? (
     <TagContainer>
-      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} />
+      <InputBar value={tagInput} onChange={onChangeTagInput} onClick={handleTagInputClick} autoFocus={isTagInputFocused} onFocus={() => setIsTagInputFocused(true)} />
       {isTagInputFocused && <SearchedTagList />}
     </TagContainer>
   ) : (

--- a/client/src/components/TaskModal/TagInput.tsx
+++ b/client/src/components/TaskModal/TagInput.tsx
@@ -53,6 +53,7 @@ const TagInput = ({ tagIdx, setTagIdx, tagList, fetchTagList, showSearchedTagLis
   //하나의 태그 선택
   const setTagItem = (idx: number) => () => {
     setTagIdx(idx);
+    setShowSearchedTagList(false);
   };
 
   const postNewTag = async () => {

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -15,7 +15,6 @@ import { HOST } from '../../constants';
 
 interface Props {
   handleCloseButtonClick: () => void;
-  fetchTaskList: () => Promise<void>;
   tagList: Tag[];
   fetchTagList: () => Promise<void>;
 }
@@ -29,7 +28,7 @@ const formatDate = (date: Date) => {
 };
 
 const DEFAULT_IMPORTANCE = 3;
-const TaskModal = ({ handleCloseButtonClick, fetchTaskList, tagList, fetchTagList }: Props) => {
+const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => {
   const [tagIdx, setTagIdx] = useState<number | null>(null);
   const [locationObject, setLocationObject] = useState<Location | null>(null); // { location, lng, lat }
   const [labelArray, setLabelArray] = useState<Label[]>([]);
@@ -91,7 +90,6 @@ const TaskModal = ({ handleCloseButtonClick, fetchTaskList, tagList, fetchTagLis
 
   const createTask = async (body: FieldValues) => {
     await httpPostTask({ ...body, date: formatDate(currentDate) });
-    await fetchTaskList();
     handleCloseButtonClick();
   };
 

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -123,8 +123,6 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
     );
   };
 
-  const tag = tagList.find((tag) => tag.idx === tagIdx);
-
   const [showSearchedTagList, setShowSearchedTagList] = useState(false);
   return (
     <S.ModalContainer isDetailOpen={isDetailOpen}>
@@ -135,7 +133,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
           <tbody>
             <Row title="제목" content={<S.InputBar {...register('title')} />} />
             <input type="number" {...register('tagIdx')} hidden={true} />
-            <Row title="태그" content={<TagInput tag={tag} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} showSearchedTagList={showSearchedTagList} setShowSearchedTagList={setShowSearchedTagList} />} />
+            <Row title="태그" content={<TagInput tagIdx={tagIdx} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} showSearchedTagList={showSearchedTagList} setShowSearchedTagList={setShowSearchedTagList} />} />
             <Row
               title="시간"
               content={

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -123,7 +123,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
     );
   };
 
-  const [showSearchedTagList, setShowSearchedTagList] = useState(false);
+  const [isTagInputFocused, setIsTagInputFocused] = useState(false);
   return (
     <S.ModalContainer isDetailOpen={isDetailOpen}>
       <S.CloseButton onClick={handleCloseButtonClick} />
@@ -133,7 +133,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
           <tbody>
             <Row title="제목" content={<S.InputBar {...register('title')} />} />
             <input type="number" {...register('tagIdx')} hidden={true} />
-            <Row title="태그" content={<TagInput tagIdx={tagIdx} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} showSearchedTagList={showSearchedTagList} setShowSearchedTagList={setShowSearchedTagList} />} />
+            <Row title="태그" content={<TagInput tagIdx={tagIdx} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} isTagInputFocused={isTagInputFocused} setIsTagInputFocused={setIsTagInputFocused} />} />
             <Row
               title="시간"
               content={

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -16,6 +16,8 @@ import { HOST } from '../../constants';
 interface Props {
   handleCloseButtonClick: () => void;
   fetchTaskList: () => Promise<void>;
+  tagList: Tag[];
+  fetchTagList: () => Promise<void>;
 }
 
 const formatDate = (date: Date) => {
@@ -27,7 +29,7 @@ const formatDate = (date: Date) => {
 };
 
 const DEFAULT_IMPORTANCE = 3;
-const TaskModal = ({ handleCloseButtonClick, fetchTaskList }: Props) => {
+const TaskModal = ({ handleCloseButtonClick, fetchTaskList, tagList, fetchTagList }: Props) => {
   const [tagIdx, setTagIdx] = useState<number | null>(null);
   const [locationObject, setLocationObject] = useState<Location | null>(null); // { location, lng, lat }
   const [labelArray, setLabelArray] = useState<Label[]>([]);
@@ -123,6 +125,9 @@ const TaskModal = ({ handleCloseButtonClick, fetchTaskList }: Props) => {
     );
   };
 
+  const tag = tagList.find((tag) => tag.idx === tagIdx);
+
+  const [isTagInputFocused, setIsTagInputFocused] = useState(false);
   return (
     <S.ModalContainer isDetailOpen={isDetailOpen}>
       <S.CloseButton onClick={handleCloseButtonClick} />
@@ -132,7 +137,7 @@ const TaskModal = ({ handleCloseButtonClick, fetchTaskList }: Props) => {
           <tbody>
             <Row title="제목" content={<S.InputBar {...register('title')} />} />
             <input type="number" {...register('tagIdx')} hidden={true} />
-            <Row title="태그" content={<TagInput tagIdx={tagIdx} setTagIdx={setTagIdx} />} />
+            <Row title="태그" content={<TagInput tag={tag} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} isTagInputFocused={isTagInputFocused} setIsTagInputFocused={setIsTagInputFocused} />} />
             <Row
               title="시간"
               content={

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -125,7 +125,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
 
   const tag = tagList.find((tag) => tag.idx === tagIdx);
 
-  const [isTagInputFocused, setIsTagInputFocused] = useState(false);
+  const [showSearchedTagList, setShowSearchedTagList] = useState(false);
   return (
     <S.ModalContainer isDetailOpen={isDetailOpen}>
       <S.CloseButton onClick={handleCloseButtonClick} />
@@ -135,7 +135,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList }: Props) => 
           <tbody>
             <Row title="제목" content={<S.InputBar {...register('title')} />} />
             <input type="number" {...register('tagIdx')} hidden={true} />
-            <Row title="태그" content={<TagInput tag={tag} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} isTagInputFocused={isTagInputFocused} setIsTagInputFocused={setIsTagInputFocused} />} />
+            <Row title="태그" content={<TagInput tag={tag} setTagIdx={setTagIdx} tagList={tagList} fetchTagList={fetchTagList} showSearchedTagList={showSearchedTagList} setShowSearchedTagList={setShowSearchedTagList} />} />
             <Row
               title="시간"
               content={


### PR DESCRIPTION
## 요약
- 태그 목록, 태그 input focus 여부를 모달에서 관리하도록 수정
- tab 키를 통해 태그 input이 focus 되었을 때 자동완성 리스트가 렌더링되지 않던 문제 해결

## 테스트 방법
1. 로그인을 완료하세요.
2. 태스크 FAB를 누르세요.
3. 태그를 등록하세요.
4. 라벨을 등록, 해제하면서 등록했던 태그가 깜빡이는지 확인하세요.

## 관련 Task
- [48] 태스크 모달 내 Tab 키로 이동 시 태그 검색결과 렌더링되지 않는 문제 → 해결
- [53] 태스크 모달 내 깜빡임 현상 → 해결

## 비고
- 이제 태그 목록이 로그 컴포넌트에서부터 props로 전달됩니다.