### PR TITLE
[BE] [8-2] 목표 조회 API 구현

### DIFF
--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const { date } = req.query;
+  if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
+  try {
+    const goals = (await executeSql(
+      'select goal.idx, goal.title, goal.label_idx as labelIdx, goal.amount as goalAmount, sum(task_label.amount) as currentAmount, goal.over from goal inner join task_label on goal.label_idx = task_label.label_idx inner join task on task_label.task_idx = task.idx where goal.user_idx = ? and task.date = ? group by goal.idx',
+      [userIdx, date]
+    )) as RowDataPacket;
+    res.json(goals);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -6,6 +6,7 @@ import tagRouter from './tag';
 import userRouter from './user';
 import friendRouter from './friend';
 import emoticonRouter from './emoticon';
+import goalRouter from './goal';
 
 const router = express.Router();
 
@@ -16,5 +17,6 @@ router.use('/tag', tagRouter);
 router.use('/user', userRouter);
 router.use('/friend', friendRouter);
 router.use('/emoticon', emoticonRouter);
+router.use('/goal', goalRouter);
 
 export default router;


### PR DESCRIPTION
## 요약
목표를 조회할 수 있는 API를 구현하였습니다.
- 요청 URL : `/goal?date=${date}`
   - `date` : 조회하고 싶은 날짜
   - method : `GET`
- 응답
   - `[ { idx, title, labelIdx,  goalAmount, currentAmount, over} ]` (목표 객체 배열)
   - 날짜 미지정 : `400`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/goal`을 통해 날짜 미지정 요청 전송
2. `400` 코드와 함께 날짜를 지정하라는 메시지가 반환됨을 확인
3. `/goal?date=2022-12-05`를 통해 목표 조회 요청
4. 목표 목록이 반환되는 것을 확인

[791cbb28-9a60-40a2-8ad1-f9733403cee3.webm](https://user-images.githubusercontent.com/92143119/205556678-382742aa-9319-4854-86c2-d136580036a2.webm)

## 작업 내용
1. 목표 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
5. 주소창에 `http://localhost:8000/api/v1/goal?date=${date}`를 입력합니다.

## 관련 Task
- [8-2]