### PR TITLE
[FE] [4-28] 친구의 LOG 조회 기능 연결

### DIFF
--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -16,11 +16,12 @@ export const FriendsBarContainer = styled.div`
 
 export const ProfileBox = styled.div<{
   imgURL: string;
+  nowVisiting?: boolean;
 }>`
   width: 2.8rem;
   height: 2.8rem;
   border-radius: 3.4rem;
-  border: 1px solid #d4d4d4;
+  border: ${(props) => (props.nowVisiting ? '5px solid #bccdec' : '1px solid #d4d4d4')};
   margin: 0 0.4rem;
   box-sizing: border-box;
   background: url(${(props) => (props.imgURL === '/plus.svg' ? props.imgURL : HOST + '/' + props.imgURL)}) no-repeat center center / ${(props) => (props.imgURL === '/plus.svg' ? '1.25rem 2.8rem' : '3.5rem 3.5rem')};

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -17,6 +17,20 @@ interface ProfileBoxProps {
 const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
 
+  const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
+    const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+
+    return (
+      <S.ProfileBox
+        imgURL={profileImg}
+        onClick={() => {
+          setCurrentVisit({ userId: userId, isMe: myProfile!.userId === userId });
+        }}
+        nowVisiting={currentVisit.userId === userId}
+      ></S.ProfileBox>
+    );
+  };
+
   return (
     <>
       <S.FriendsBarContainer>
@@ -32,8 +46,3 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
 };
 
 export default FriendsBar;
-
-const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
-  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
-  return <S.ProfileBox imgURL={profileImg} onClick={() => setCurrentVisit(userId)}></S.ProfileBox>;
-};

--- a/client/src/components/MainContainer/Diary.style.ts
+++ b/client/src/components/MainContainer/Diary.style.ts
@@ -7,20 +7,31 @@ export const DiaryTitle = styled.span`
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
   z-index: 1;
+  span {
+    font-size: 1.2rem;
+  }
 `;
 
-export const Container = styled.div``;
-
-export const DiaryContainer = styled.div`
+export const Container = styled.div`
   height: 36rem;
   background: white;
   border-radius: 1rem;
   margin-top: 0rem;
   margin-bottom: 1rem;
   padding: 0.5rem;
-  position: relative;
   box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
+`;
+
+export const DiaryContainer = styled.div`
+  position: relative;
   user-select: none;
+  width: 100;
+  height: 100;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  //justify-content: center;
 `;
 
 export const DiaryNavBarSection = styled.div`

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -13,14 +13,16 @@ const Diary = () => {
 
   useEffect(() => {
     const currentDateString = dateToString();
-    globalSocket.emit('joinToNewRoom', currentVisit, currentDateString);
+    globalSocket.emit('joinToNewRoom', currentVisit.userId, currentDateString);
     return () => {
-      globalSocket.emit('leaveCurrentRoom', currentVisit, currentDateString);
+      globalSocket.emit('leaveCurrentRoom', currentVisit.userId, currentDateString);
     };
   }, [currentVisit, currentDate]);
   return (
     <>
-      <S.DiaryTitle>DIARY</S.DiaryTitle>
+      <S.DiaryTitle>
+        DIARY <span> {currentVisit.isMe || `~${currentVisit.userId}`}</span>
+      </S.DiaryTitle>
       <S.Container>
         <S.DiaryContainer>
           <S.DiaryNavBarSection>

--- a/client/src/components/MainContainer/Log.style.ts
+++ b/client/src/components/MainContainer/Log.style.ts
@@ -48,6 +48,19 @@ export const DeleteIcon = styled(RiDeleteBin2Fill)`
   margin: 0px 2px 0px 2px;
 `;
 
+export const LogContainer = styled.div`
+  width: 100%;
+  height: 37rem;
+  background: white;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
+  user-select: none;
+`;
+
 export const LogTitle = styled.span`
   display: inline-block;
   color: white;
@@ -55,23 +68,21 @@ export const LogTitle = styled.span`
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
   z-index: 1;
+  span {
+    font-size: 1.2rem;
+  }
 `;
 
-export const Container = styled.div``;
-
-export const LogContainer = styled.div`
+export const Grid = styled.div`
   display: grid;
-  padding: 0.5rem;
+  width: 43.5rem;
   height: 36rem;
-  background: white;
-  border-radius: 1rem;
   position: relative;
   grid-template-areas:
     'time nav'
     'time main';
   grid-template-columns: 1fr 16fr;
   grid-template-rows: 1fr 10fr;
-  box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
   user-select: none;
 `;
 
@@ -183,7 +194,7 @@ export const TaskItem = styled.div<{
   width: 12.5rem;
   min-height: 2.1rem;
   max-height: 3rem;
-  transition: all 0.4s ease-out;
+  transition: min-height 0.4s ease-out;
 
   margin: 0.25rem 0.25rem;
   display: flex;
@@ -319,7 +330,7 @@ export const NewTaskButton = styled(FiPlus)`
   position: absolute;
   color: white;
   font-size: 1.6rem;
-  left: 40.5rem;
+  left: 40rem;
   bottom: 1rem;
   padding: 0.5rem;
   width: 2rem;

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -8,6 +8,8 @@ import { HOST } from '../../constants';
 import useCurrentDate from '../../hooks/useCurrentDate';
 import Modal from '../common/Modal';
 import TaskModal from '../TaskModal/TaskModal';
+import { useRecoilState } from 'recoil';
+import { visitState } from '../common/atoms';
 
 interface Tag {
   idx: number;
@@ -29,6 +31,8 @@ const Log = () => {
   const { currentDate } = useCurrentDate();
   const [tagList, setTagList] = useState<Tag[]>([]);
 
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+
   const fetch = async () => {
     await fetchTagList();
     await fetchTaskList();
@@ -48,25 +52,25 @@ const Log = () => {
   };
 
   const fetchTagList = async () => {
-    const response = await axios.get(`${HOST}/api/v1/tag`);
+    const response = currentVisit.isMe ? await axios.get(`${HOST}/api/v1/tag`) : await axios.get(`${HOST}/api/v1/tag/${currentVisit.userId}`);
     const tagList = response.data;
     setTagList(tagList);
   };
 
   const fetchTaskList = async () => {
     const date = currentDate.toLocaleDateString().split('. ').join('-').substring(0, 10);
-    const response = await axios.get(`${HOST}/api/v1/task?date=${date}`);
+    const response = currentVisit.isMe ? await axios.get(`${HOST}/api/v1/task?date=${date}`) : await axios.get(`${HOST}/api/v1/task/${currentVisit.userId}?date=${date}`);
     const taskList = response.data;
     setTaskList(taskList);
   };
 
   useEffect(() => {
     fetchTagList();
-  }, []);
+  }, [currentVisit]);
 
   useEffect(() => {
     fetchTaskList();
-  }, [currentDate]);
+  }, [currentDate, currentVisit]);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!(e.target instanceof HTMLDivElement)) return;
@@ -181,9 +185,11 @@ const Log = () => {
           <span>{TaskMap.get(selectedTask.idx).startedAt}</span> {TaskMap.get(selectedTask.idx).title}
         </S.SelectedItem>
       )}
-      <S.LogTitle>LOG</S.LogTitle>
-      <S.Container>
-        <S.LogContainer>
+      <S.LogTitle>
+        LOG<span> {currentVisit.isMe || `~${currentVisit.userId}`}</span>
+      </S.LogTitle>
+      <S.LogContainer>
+        <S.Grid>
           <S.TimeBarSection>
             <img src="/timebar-clock.svg" alt="TimeBar" />
             <S.TimeBar>
@@ -219,10 +225,10 @@ const Log = () => {
             })}
             <S.SlideObserver data-direction="right" direction="right"></S.SlideObserver>
           </S.LogMainSection>
-          <S.NewTaskButton onClick={() => setIsModalOpen(true)} />
+          {currentVisit.isMe && <S.NewTaskButton onClick={() => setIsModalOpen(true)} />}
           {isModalOpen && <Modal component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} fetchTaskList={fetchTaskList} />} zIndex={1001} top="50%" left="50%" transform="translate(-50%, -50%)" handleDimmedClick={() => {}} />}
-        </S.LogContainer>
-      </S.Container>
+        </S.Grid>
+      </S.LogContainer>
     </>
   );
 };

--- a/client/src/components/MainContainer/TaskItem.tsx
+++ b/client/src/components/MainContainer/TaskItem.tsx
@@ -3,6 +3,8 @@ import { Task, CompletionCheckBoxStatus } from 'GlobalType';
 import { useEffect } from 'react';
 import { HOST } from '../../constants';
 import * as S from './Log.style';
+import { visitState } from '../common/atoms';
+import { useRecoilState } from 'recoil';
 
 interface taskListProps {
   taskList: Task[];
@@ -12,6 +14,8 @@ interface taskListProps {
 }
 
 const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: taskListProps) => {
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+
   const isTaskFiltered = (done: boolean) => {
     if (done && !completionFilter.complete) return true;
     else if (!done && !completionFilter.incomplete) return true;
@@ -34,6 +38,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
     if (task.location) count++;
     if (task.content && task.content !== '') count += 4.6; // 2.3;
     if (task.labels.length !== 0) count += Math.ceil(task.labels.length / 2) * 1.5 + 0.8;
+    if (!currentVisit.isMe) count = count - 2;
     return count;
   };
 
@@ -41,7 +46,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
     //코멘트 조회
 
     return (
-      <S.Container>
+      <>
         <hr />
         <S.TaskDetailInfos>
           <S.TaskDetailInfosCol>
@@ -82,26 +87,30 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
           </>
         )}
 
-        {/* 해당 메뉴는 나의 Task 조회시에만 표시*/}
-        <hr />
-        <S.TaskDetailInfos>
-          <S.TaskDetailInfosCol height="1.3rem">
-            <S.TaskDetailIcon htmlFor="done">
-              <S.CheckBox type="checkbox" id="done" data-idx={task.idx} defaultChecked={task.done} onChange={patchTaskDone} />
-              완료
-            </S.TaskDetailIcon>
+        {currentVisit.isMe && (
+          <>
+            <hr />
 
-            <S.TaskDetailIcon>
-              <S.EditIcon />
-              수정
-            </S.TaskDetailIcon>
-            <S.TaskDetailIcon>
-              <S.DeleteIcon />
-              삭제
-            </S.TaskDetailIcon>
-          </S.TaskDetailInfosCol>
-        </S.TaskDetailInfos>
-      </S.Container>
+            <S.TaskDetailInfos>
+              <S.TaskDetailInfosCol height="1.3rem">
+                <S.TaskDetailIcon htmlFor="done">
+                  <S.CheckBox type="checkbox" id="done" data-idx={task.idx} defaultChecked={task.done} onChange={patchTaskDone} />
+                  완료
+                </S.TaskDetailIcon>
+
+                <S.TaskDetailIcon>
+                  <S.EditIcon />
+                  수정
+                </S.TaskDetailIcon>
+                <S.TaskDetailIcon>
+                  <S.DeleteIcon />
+                  삭제
+                </S.TaskDetailIcon>
+              </S.TaskDetailInfosCol>
+            </S.TaskDetailInfos>
+          </>
+        )}
+      </>
     );
   };
 

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -6,5 +6,5 @@ export const dateState = atom({
 });
 export const visitState = atom({
   key: 'currentVisiting',
-  default: '',
+  default: { userId: '', isMe: true },
 });

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -20,6 +20,7 @@ const MainPage = () => {
   const [myProfile, setMyProfile] = useState<Friend | null>(null);
   const [friendsList, setFriendsList] = useState<Friend[] | null>(null);
   const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+
   const [friendRequests, setFriendRequests] = useState<Friend[] | null>(null);
 
   //API Requests
@@ -94,7 +95,7 @@ const MainPage = () => {
     getFriendsList();
     getFriendRequests();
     getMyProfile().then((userData: Friend) => {
-      setCurrentVisit(userData.userId);
+      setCurrentVisit((prev) => ({ isMe: true, userId: userData.userId }));
     });
   }, []);
 


### PR DESCRIPTION
## 요약
친구의 프로필을 클릭하면 친구의 테스크를 표시하는 기능을 연결했습니다

## 작동 화면
![Dec-05-2022 14-37-01](https://user-images.githubusercontent.com/73420533/205557525-63f81b3a-9b79-432e-94b5-655f293f96af.gif)
- 상단 친구 바에 조회하고 있는 유저가 border 처리 되어 나타난다
- 친구 아이콘을 클릭 시 친구의 LOG를 조회한다.
  - 조회하고 있는 친구의 아이디가 타이틀에 나타난다.
  - 친구의 LOG 조회 시에는 완료 수정 삭제 버튼과 생성 버튼이 보이지 않는다.

## 작업 내용
**1. 전역변수 currentVisit을 { userId, isMe } 객체로 구체화했습니다. 아이디를 사용하기 위해서는 currentVisit.userId로 사용해주세요!!!** Diary 파일에서는 바꿔놨는데 빠뜨린 부분이 있을 수도 있으니까 확인해주세요
2. LOG / DIARY 탭 상단 아이디 표시
3. LOG / DIARY 탭 타이틀이 그림자 뒤에 보이는 문제 해결 및 css 조정

## 관련 Task
4-28. 친구의 프로필을 클릭하면 친구의 테스크를 표시한다.
60. LOG DIARY 탭 타이틀이 그림자 뒤에 보이는 문제
50. 태스크 이동 시 잔상이 남는 문제

## 비고
- 캘린더가 연결되면 친구의 task 조회가 훨씬 수월해질 것 같습니다
- 다이어리 탭은 기능 완성되시면 css 조정 맡아서 하도록 할게요!