### PR TITLE
[BE] [4-30] 친구의 라벨 조회 API 구현

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { OkPacket, RowDataPacket } from 'mysql2';
+import { API_VERSION } from '../constants';
 import { executeSql } from '../db';
 import { AuthorizedRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
@@ -12,6 +13,27 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
     const labels = await executeSql('select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) as count from label left join task_label on label.idx = task_label.label_idx where label.user_idx = ? group by label.idx', [
       userIdx,
     ]);
+    res.json(labels);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+router.get('/:user_id', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const { user_id: friendId } = req.params;
+
+  try {
+    const friend = (await executeSql('select idx from user where user_id = ?', [friendId])) as RowDataPacket;
+    if (friend.length === 0) return res.status(404).send({ msg: '존재하지 않는 사용자예요.' });
+
+    const { idx: friendIdx } = friend[0];
+    if (userIdx === friendIdx) return res.redirect(`/api/${API_VERSION}/label`);
+
+    const isNotFriend = ((await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket).length === 0;
+    if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 라벨을 조회할 수 없어요.' });
+
+    const labels = await executeSql('select idx, title, color, unit from label where label.user_idx = ?', [friendIdx]);
     res.json(labels);
   } catch {
     res.sendStatus(500);


### PR DESCRIPTION
## 요약
친구의 라벨을 조회할 수 있는 API를 구현하였습니다.
친구인 사용자에 한해서만 라벨을 조회할 수 있습니다.
- 요청 URL : `/label/:user_id`
   - `user_id` : 조회하고 싶은 친구의 id
   - method : `GET`
- 응답
   - `[ { idx, title, color, unit } ]` (라벨 객체 배열)
      - **친구의 라벨 조회의 경우 `count`가 불필요할 것으로 예상되어 제외하였습니다.
         `count`는 join 연산을 통해 얻는 값으로 불필요하다면 제외하는 것이 성능 상의 이점을 가진다고 판단하여 제외하게 되었습니다.
         필요할 경우 요청해주시면 `count`도 응답에 포함시키겠습니다.**
   - 자신에 대한 요청 : `/label`로 redirect 처리하여 자신의 라벨을 조회하는 API 요청
   - 친구가 아닌 사용자에 대한 요청 : `403`
   - 존재하지 않는 사용자에 대한 요청 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 자신에 대한 요청
1. 자신의 아이디 `pikachu`에 대한 요청인 `/label/pikachu`을 통해 `/label`로 redirect 처리되는 것을 확인

[9c49cb85-0440-4f06-a9d7-edbcdd422632.webm](https://user-images.githubusercontent.com/92143119/205560589-d891a4f6-52eb-4c27-bb27-141623a231a4.webm)
### 존재하지 않는 사용자에 대한 요청, 친구가 아닌 사용자에 대한 요청
1. 존재하지 않는 사용자 `sysysys`에 대한 요청인 `/label/sysysys`을 통해 `404` 코드와 존재하지 않는 사용자라는 메시지가 반환됨을 확인
2. 친구가 아닌 사용자 `j0702`에 대한 요청인 `/label/j0702`을 통해 `403` 코드와 친구가 아닌 사용자의 라벨을 조회할 수 없다는 메시지가 반환됨을 확인
 
[5a5d225e-6016-4f09-921c-fa971bf79367.webm](https://user-images.githubusercontent.com/92143119/205560734-59d27eb9-4e9a-44d6-b09e-3d95cb0fedcb.webm)
#### 친구의 라벨 조회 요청
1. 친구인 사용자 `sy`에 대한 요청인 `/label/sy`을 통해 라벨의 목록이 조회되는 것을 확인

[c59927b3-8872-4e6e-bbb9-30cebd1b7d63.webm](https://user-images.githubusercontent.com/92143119/205560758-b3e84ac9-a4a5-4d1f-908f-9dfa60e3a5ff.webm)

## 작업 내용
1. 친구의 라벨 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
3. 주소창에 `http://localhost:8000/api/v1/label/${user_id}`를 입력합니다.

## 관련 Task
- [4-30]