### PR TITLE
[BE] [8-10] 목표 수정 API 구현

### DIFF
--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -21,4 +21,27 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
+router.put('/:goal_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const goalIdx = req.params.goal_idx;
+
+  try {
+    Object.values(GoalBodyKeys).forEach((key) => validate(key, req.body[key]));
+  } catch (error) {
+    return res.status(400).send({ msg: error.message });
+  }
+
+  const { title, labelIdx, amount, over } = req.body;
+
+  try {
+    const existGoal = ((await executeSql('select idx from goal where user_idx = ? and idx = ?', [userIdx, goalIdx])) as RowDataPacket).length > 0;
+    if (!existGoal) return res.status(404).json({ msg: '존재하지 않는 목표예요.' });
+
+    await executeSql('update goal set title = ?, label_idx = ?, amount = ?, over = ? where idx = ?;', [title, labelIdx, amount, over, goalIdx]);
+    res.sendStatus(200);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
 export default router;

--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -37,6 +37,9 @@ router.put('/:goal_idx', authenticateToken, async (req: AuthorizedRequest, res) 
     const existGoal = ((await executeSql('select idx from goal where user_idx = ? and idx = ?', [userIdx, goalIdx])) as RowDataPacket).length > 0;
     if (!existGoal) return res.status(404).json({ msg: '존재하지 않는 목표예요.' });
 
+    const existLabel = ((await executeSql('select idx from label where user_idx = ? and idx = ?', [userIdx, labelIdx])) as RowDataPacket).length > 0;
+    if (!existLabel) return res.status(404).json({ msg: '존재하지 않는 라벨이에요.' });
+
     await executeSql('update goal set title = ?, label_idx = ?, amount = ?, over = ? where idx = ?;', [title, labelIdx, amount, over, goalIdx]);
     res.sendStatus(200);
   } catch {


### PR DESCRIPTION
## 요약
목표를 수정할 수 있는 API를 구현하였습니다.
목표의 `date`는 수정이 불가능합니다.
해당 API를 통해 `date`에 대한 수정 요청을 하더라도 수정되지 않고 기존의 값이 유지됩니다.
- 요청 URL : `/goal/:goal_idx`
   - Request Body
      - `{ title: string, date: string(yyyy-mm-dd), labelIdx: number, amount: number, over: boolean }`
      - 모두 필수 항목이지만 `date`의 경우 수정값을 입력하여도 기존 값이 유지됨
   - method : `PUT`
- 응답
   - 목표 수정 성공 : `200`
   - 유효하지 않은 입력 : `400`
   - 존재하지 않는 목표 및 라벨 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 유효하지 않은 입력, 존재하지 않는 목표에 대한 요청
1. `/goal?date=2022-12-05`를 통해 목표 목록 확인
2. `labelIdx`를 입력하지 않은 목표 수정 요청
3. `400` 코드가 반환되는 것을 확인
4. 존재하지 않는 `idx=100` 목표에 대한 수정 요청
5. `404` 코드가 반환되는 것을 확인

[51388172-bd83-4abe-9e89-21927b161604.webm](https://user-images.githubusercontent.com/92143119/205705979-e9ba80e4-9307-4dbd-9c33-ea18bb7e25ce.webm)
### 목표 수정 요청
1. `/goal?date=2022-12-05`를 통해 목표 목록 확인
2. `date = 2022-12-06` 수정값을 포함한 `idx = 5` 목표에 대한 수정 요청
3. `/goal?date=2022-12-05`를 통해 `date`를 제외한 수정 요청이 정상적으로 이루어진 것을 확인

[d69d35c7-cca6-480c-9854-7e6f88ea0087.webm](https://user-images.githubusercontent.com/92143119/205705996-75990c55-cc1a-4115-89ba-111dbd1c902a.webm)

## 작업 내용
1. 목표 수정 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/goal/${goal_idx}', {
     method: 'PUT',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
        title: ${title},
        date: ${date},
        labelIdx: ${labelIdx},
        amount: ${amount},
        over: ${over},
     }),
   });
   ```

## 관련 Task
- [8-10]