### PR TITLE
[BE] [8-11] 목표 삭제 API 구현

### DIFF
--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -21,4 +21,19 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
+router.delete('/:goal_idx', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const goalIdx = req.params.goal_idx;
+
+  try {
+    const existGoal = ((await executeSql('select idx from goal where user_idx = ? and idx = ?', [userIdx, goalIdx])) as RowDataPacket).length > 0;
+    if (!existGoal) return res.status(404).json({ msg: '존재하지 않는 목표예요.' });
+
+    await executeSql('delete from goal where idx = ?', [goalIdx]);
+    res.sendStatus(200);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## 요약
목표를 삭제할 수 있는 API를 구현하였습니다.
- 요청 URL : `/goal/:goal_idx`
   - method : `DELETE`
- 응답
   - 목표 삭제 성공 : `200`
   - 존재하지 않는 목표 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/goal?date=2022-12-05`를 통해 목표 목록 확인
2. 존재하지 않는 `idx = 50` 목표에 대한 삭제 요청
3. `404` 코드가 반환되는 것을 확인
4. `idx = 5` 목표에 대한 삭제 요청
5. `/goal?date=2022-12-05`를 통해 목표가 정상적으로 삭제된 것을 확인

[d6d57a1b-d619-4703-b6fe-8eec721430bf.webm](https://user-images.githubusercontent.com/92143119/205708268-af1be33d-61ad-42e1-a35c-b952e7f265a5.webm)

## 작업 내용
1. 목표 삭제 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/goal/${goal_idx}', {
     method: 'DELETE',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
   });
   ```

## 관련 Task
- [8-11]