### PR TITLE
[BE] [6-3] Diary canvas 도형 redis에 저장

### DIFF
--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -263,7 +263,6 @@ const Canvas = () => {
     Object.values(objectDataMap).forEach((objectData) => {
       updateModifiedObject(objectData);
     });
-    console.log('objects');
   };
   const setCanvasBackground = () => {
     fabric.Image.fromURL(canvasBackground, function (img) {
@@ -275,7 +274,6 @@ const Canvas = () => {
       img.scaleToWidth(674);
       img.setCoords();
       if (!canvasRef.current) return;
-      console.log('img');
       canvasRef.current.add(img);
       globalSocket.emit('requestCurrentObjects');
     });

--- a/server/app.ts
+++ b/server/app.ts
@@ -77,7 +77,7 @@ io.on('connection', (socket) => {
     const targetObjects = diaryObjects[roomName];
     io.to(socket.id).emit('offerCurrentObjects', targetObjects);
   });
-  socket.on('sendModifiedObject', async (objectData) => {
+  socket.on('sendModifiedObject', (objectData) => {
     const roomName = visitingRoom.get(socket.id);
     const targetObjects = diaryObjects[roomName];
     const objectId = objectData.id;

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,11 +1,12 @@
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import { CLIENT, PORT, API_VERSION } from './src/constants';
+import { CLIENT, PORT, API_VERSION, REDIS_HOST, REDIS_USERNAME, REDIS_PORT, REDIS_PASSWORD } from './src/constants';
 import apiRouter from './src/api/index';
 import cors from 'cors';
 import path from 'path';
 import { Server } from 'socket.io';
 import http from 'http';
+import * as redis from 'redis';
 
 const app = express();
 const httpServer = http.createServer(app);
@@ -19,6 +20,25 @@ const corsOptions = {
 const io = new Server(httpServer, {
   cors: corsOptions,
 });
+const redisclient = redis.createClient({
+  url: `redis://${REDIS_USERNAME}:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/0`,
+  legacyMode: true,
+});
+redisclient.on('connect', () => {
+  console.info('redis connected');
+});
+redisclient.on('error', (err) => {
+  console.error('redisError', err);
+});
+redisclient.connect().then();
+const redisCli = redisclient.v4;
+
+const setDiary = async (roomName: string, data: any) => {
+  await redisCli.set(roomName, JSON.stringify(data));
+};
+const getDiary = async (roomName: string) => {
+  return JSON.parse(await redisCli.get(roomName));
+};
 
 app.use(express.json());
 app.use(cookieParser());
@@ -35,23 +55,29 @@ const diaryObjects = {};
 const visitingRoom = new Map();
 
 io.on('connection', (socket) => {
-  socket.on('joinToNewRoom', (destId, date) => {
+  socket.on('joinToNewRoom', async (destId, date) => {
     const roomName = destId + date;
-    socket.join(roomName);
     visitingRoom.set(socket.id, roomName);
+    socket.join(roomName);
+    if (io.sockets.adapter.rooms.get(roomName).size === 1) {
+      const diaryData = (await getDiary(roomName)) || {};
+      diaryObjects[roomName] = diaryData;
+    }
   });
-  socket.on('leaveCurrentRoom', (destId, date) => {
+  socket.on('leaveCurrentRoom', async (destId, date) => {
     const roomName = destId + date;
     socket.leave(roomName);
-    visitingRoom.delete(socket.id);
+    if (!io.sockets.adapter.rooms.get(roomName)) {
+      const diaryData = diaryObjects[roomName] || {};
+      await setDiary(roomName, diaryData);
+    }
   });
   socket.on('requestCurrentObjects', () => {
     const roomName = visitingRoom.get(socket.id);
-    if (!diaryObjects[roomName]) diaryObjects[roomName] = {};
     const targetObjects = diaryObjects[roomName];
     io.to(socket.id).emit('offerCurrentObjects', targetObjects);
   });
-  socket.on('sendModifiedObject', (objectData) => {
+  socket.on('sendModifiedObject', async (objectData) => {
     const roomName = visitingRoom.get(socket.id);
     const targetObjects = diaryObjects[roomName];
     const objectId = objectData.id;

--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -20,3 +20,7 @@ export const OAUTH_TYPES = {
 } as const;
 export const HOST = process.env.MODE === 'dev' ? process.env.DEV_HOST : process.env.PROD_HOST;
 export const DEFAULT_PROFILE = 'default_profile.png';
+export const REDIS_USERNAME = process.env.REDIS_USERNAME;
+export const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
+export const REDIS_HOST = process.env.REDIS_HOST;
+export const REDIS_PORT = process.env.REDIS_PORT;


### PR DESCRIPTION
## 요약
redis 클라우드에 diary canvas 도형을 저장하고 불러옵니다
## 작동 화면
기존과 동작은 같으며 중간에 redis에 데이터를 저장하고 불러오는 로직이 추가되었습니다.

## 작업 내용
1. redis 클라우드에 접속
2. socket room에 join시 처음접속했다면 redis에서 해당유저/일자에 해당하는 diary 도형 객체 로드하여 객체에 저장
3. 이후 자잘한 도형 추가/수정/삭제는 redis가 아닌 임시 데이터 객체에서 실행
4. socket room에서 leave시 마지막 사람이라면 임시 데이터를 해당유저/일자에 해당하는 key로 redis에 저장

## 테스트 방법
1. 로그인하여 diary에 그림을 그린다
2. 접속해제후 dev 서버를 종료한다.
3. 다시 dev서버 실행 후 diary data가 남아있는지 확인한다.

## 관련 Task
- [6-3], [6-4]

## 비고
