### PR TITLE
[BE] [63] 목표 조회 API 수정

### DIFF
--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -39,7 +39,7 @@ router.get('/:user_id', authenticateToken, async (req: AuthorizedRequest, res) =
     if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 목표를 조회할 수 없어요.' });
 
     const goals = (await executeSql(
-      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, ifnull(sum(task_label.amount), 0) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
+      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
       [friendIdx, date, friendIdx, date]
     )) as RowDataPacket;
     res.json(goals);

--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -13,7 +13,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
   try {
     const goals = (await executeSql(
-      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, ifnull(sum(task_label.amount), 0) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
+      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
       [userIdx, date, userIdx, date]
     )) as RowDataPacket;
     res.json(goals);

--- a/server/src/api/goal.ts
+++ b/server/src/api/goal.ts
@@ -13,7 +13,7 @@ router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   if (!date) return res.status(400).send({ msg: '날짜를 지정해주세요.' });
   try {
     const goals = (await executeSql(
-      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
+      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where done = true and user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
       [userIdx, date, userIdx, date]
     )) as RowDataPacket;
     res.json(goals);
@@ -39,7 +39,7 @@ router.get('/:user_id', authenticateToken, async (req: AuthorizedRequest, res) =
     if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 목표를 조회할 수 없어요.' });
 
     const goals = (await executeSql(
-      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
+      'select idx, title, goal.label_idx as labelIdx, goal.amount as goalAmount, cast(ifnull(sum(task_label.amount), 0) as unsigned) as currentAmount, over from goal left join (select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where done = true and user_idx = ? and date = ?) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date = ? group by idx',
       [friendIdx, date, friendIdx, date]
     )) as RowDataPacket;
     res.json(goals);


### PR DESCRIPTION
## 요약
1. 목표 조회 API 요청 시 반환되는 응답 중 `currentAmount`의 타입을 숫자로 변경하였습니다.
   MySQL 내에서 `sum()`의 결과가 문자열로 반환되어 `currentAmount`의 타입도 문자열로 반환되는 상황이었습니다.
   `cast()`를 통해 `unsigned`로 타입을 변경하여 해결하였습니다.
   응답 및 요청 등의 내용에는 변경 사항이 없습니다.
2. `currentAmount` 계산 시 `done = true`인 태스크의 내용만 반영하도록 수정하였습니다.
   태스크에 라벨을 설정하더라도 해당 태스크를 완료하기 전까지는 목표에 반영되지 않습니다.

## 작동 화면
1. `/goal?date=2022-12-05`를 통해 목표 조회 요청
2. `currentAmount`의 값이 숫자로 반환되는 것을 확인

[ab81bc20-add7-4a78-94b0-bb49a8f9225b.webm](https://user-images.githubusercontent.com/92143119/205827916-4e3dd215-ded2-4ebe-aab4-38a876a7ffbd.webm)

## 작업 내용
1. 목표 조회 API의 `currentAmount` 타입 수정
2. `currentAmount` 계산 시 `done = true`인 태스크만 반영하도록 수정

## 테스트 방법
1. 로그인을 완료합니다.
3. 주소창에 `http://localhost:8000/api/v1/goal?date=${date}`를 입력합니다.

## 관련 Task
- [63]