### PR TITLE
[FE] [4-24] 친구프로필조회/삭제 모달 생성

### DIFF
--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -29,3 +29,52 @@ export const ProfileBox = styled.div<{
     border: 5px solid #bccdec;
   }
 `;
+
+export const FriendMenuModal = styled.div`
+  height: 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  background-color: #eef3fd;
+  border: #7689fd solid 1px;
+  border-radius: 5px;
+  margin-top: 6.8px;
+  padding: 5px 11px;
+  position: absolute;
+  width: fit-content;
+  z-index: 800;
+  &::after {
+    content: '';
+    width: 0;
+    display: block;
+    position: absolute;
+    border-color: #eef3fd transparent;
+    border-style: solid;
+    border-width: 0 6px 8px 6.5px;
+    top: -7px;
+    left: 1.375rem;
+    z-index: 1;
+  }
+  &::before {
+    border-color: #7689fd transparent;
+    border-style: solid;
+    border-width: 0 6px 8px 6.5px;
+    content: '';
+    display: block;
+    left: 1.375rem;
+    position: absolute;
+    top: -8px;
+    width: 0;
+    z-index: 0;
+  }
+`;
+
+export const FriendMenuModalItem = styled.div`
+  color: var(--color-main);
+  font-size: 1rem;
+  cursor: pointer;
+  &:hover {
+    font-weight: 700;
+    color: #505bf0;
+  }
+`;

--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -31,7 +31,7 @@ export const ProfileBox = styled.div<{
 `;
 
 export const FriendMenuModal = styled.div`
-  height: 4rem;
+  height: 3.5rem;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
@@ -71,7 +71,7 @@ export const FriendMenuModal = styled.div`
 
 export const FriendMenuModalItem = styled.div`
   color: var(--color-main);
-  font-size: 1rem;
+  font-size: 0.75rem;
   cursor: pointer;
   &:hover {
     font-weight: 700;

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { Friend } from 'GlobalType';
 import * as S from './FriendsBar.style';
@@ -16,18 +16,34 @@ interface ProfileBoxProps {
 
 const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
+  const [friendMenuIndex, setFriendMenuIndex] = useState<string | null>(null);
 
   const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
     const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
 
+    const closeFriendMenuModal = () => {
+      setFriendMenuIndex(null);
+      document.removeEventListener('click', closeFriendMenuModal);
+    };
+    const handleRightClick = (e: React.MouseEvent, userId: string) => {
+      e.preventDefault();
+      setFriendMenuIndex(userId);
+      document.addEventListener('click', closeFriendMenuModal);
+    };
     return (
-      <S.ProfileBox
-        imgURL={profileImg}
-        onClick={() => {
-          setCurrentVisit({ userId: userId, isMe: myProfile!.userId === userId });
-        }}
-        nowVisiting={currentVisit.userId === userId}
-      ></S.ProfileBox>
+      <>
+        <div>
+          <S.ProfileBox
+            imgURL={profileImg}
+            onClick={() => {
+              setCurrentVisit({ userId: userId, isMe: myProfile!.userId === userId });
+            }}
+            onContextMenu={(e) => handleRightClick(e, userId)}
+            nowVisiting={currentVisit.userId === userId}
+          ></S.ProfileBox>
+          {friendMenuIndex === userId && userId !== myProfile?.userId && <FriendMenuModal></FriendMenuModal>}
+        </div>
+      </>
     );
   };
 
@@ -46,3 +62,14 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
 };
 
 export default FriendsBar;
+
+const FriendMenuModal = () => {
+  return (
+    <>
+      <S.FriendMenuModal>
+        <S.FriendMenuModalItem>프로필보기</S.FriendMenuModalItem>
+        <S.FriendMenuModalItem>삭제하기</S.FriendMenuModalItem>
+      </S.FriendMenuModal>
+    </>
+  );
+};

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -16,18 +16,18 @@ interface ProfileBoxProps {
 
 const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
-  const [friendMenuIndex, setFriendMenuIndex] = useState<string | null>(null);
+  const [friendMenuId, setFriendMenuId] = useState<string | null>(null);
 
   const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
     const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
 
     const closeFriendMenuModal = () => {
-      setFriendMenuIndex(null);
+      setFriendMenuId(null);
       document.removeEventListener('click', closeFriendMenuModal);
     };
     const handleRightClick = (e: React.MouseEvent, userId: string) => {
       e.preventDefault();
-      setFriendMenuIndex(userId);
+      setFriendMenuId(userId);
       document.addEventListener('click', closeFriendMenuModal);
     };
     return (
@@ -41,7 +41,7 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
             onContextMenu={(e) => handleRightClick(e, userId)}
             nowVisiting={currentVisit.userId === userId}
           ></S.ProfileBox>
-          {friendMenuIndex === userId && userId !== myProfile?.userId && <FriendMenuModal></FriendMenuModal>}
+          {friendMenuId === userId && userId !== myProfile?.userId && <FriendMenuModal></FriendMenuModal>}
         </div>
       </>
     );

--- a/client/src/components/MainContainer/Calendar.style.ts
+++ b/client/src/components/MainContainer/Calendar.style.ts
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 export const CalendarTitle = styled.span`
   display: inline-block;
   color: white;
+  position: relative;
   font-size: 1.7rem;
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
-  z-index: 1;
+  z-index: -1;
 `;
 export const CalendarContainer = styled.div`
   width: 100%;


### PR DESCRIPTION
## 요약
친구Bar의 프로필사진에서 우클릭하면 프로필조회와 친구삭제가 가능한 모달이 생성됩니다

## 작동 화면
![친구메뉴 모달](https://user-images.githubusercontent.com/109147404/205968844-9b979c8a-4363-4ca8-8c87-e12388be0656.gif)

## 작업 내용
1. 우클릭시 선택한 친구의 id 상태로 관리
2. 선택한ID의 친구 아래 프로필조회/친구삭제가 가능한 모달 생성
3. 이외 영역을 클릭하면 선택한 친구 state를 null로 변경

## 테스트 방법
1.로그인하여 친구창의 친구프로필사진 위에서 우클릭을 한다.

## 관련 Task
-[4-24]

## 비고
