### PR TITLE
[BE] [5-4] 일별 태스크 존재 여부 조회 API 구현

### DIFF
--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+const CalendarQueryKeys = {
+  year: 'year',
+  month: 'month',
+} as const;
+
+type CalendarQueryKeys = typeof CalendarQueryKeys[keyof typeof CalendarQueryKeys];
+
+class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+const validate = (key: string, value: string) => {
+  switch (key) {
+    case CalendarQueryKeys.year: {
+      const year = parseInt(value);
+      if (isNaN(year)) throw new ValidationError('올바른 연도를 입력해주세요.');
+      return true;
+    }
+    case CalendarQueryKeys.month: {
+      const month = parseInt(value);
+      if (isNaN(month) || month < 1 || month > 12) throw new ValidationError('올바른 달을 입력해주세요.');
+      return true;
+    }
+    default: {
+      throw new ValidationError('잘못된 정보가 입력되었어요.');
+    }
+  }
+};
+
+router.get('/task', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+
+  try {
+    Object.values(CalendarQueryKeys).forEach((key) => validate(key, req.query[key] as string));
+  } catch (error) {
+    return res.status(400).send({ msg: error.message });
+  }
+
+  const year = parseInt(req.query.year as string);
+  const month = parseInt(req.query.month as string);
+
+  const dateSearchFormat = `${year}-${month}-%`;
+  const lastDate = new Date(year, month, 0);
+  const lastDay = lastDate.getDate();
+
+  const result = Array.from({ length: lastDay }, () => false);
+  try {
+    const datesTaskExists = (await executeSql('select date_format(date, "%d") as date, count(idx) from task where user_idx = ? and date like ? group by date', [userIdx, dateSearchFormat])) as RowDataPacket;
+    datesTaskExists.forEach(({ date }) => {
+      result[parseInt(date) - 1] = true;
+    });
+
+    res.send(result);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -60,7 +60,7 @@ router.get('/task', authenticateToken, async (req: AuthorizedRequest, res) => {
       result[parseInt(date) - 1] = true;
     });
 
-    res.send(result);
+    res.json(result);
   } catch {
     res.sendStatus(500);
   }

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -7,6 +7,7 @@ import userRouter from './user';
 import friendRouter from './friend';
 import emoticonRouter from './emoticon';
 import goalRouter from './goal';
+import calendarRouter from './calendar';
 
 const router = express.Router();
 
@@ -18,5 +19,6 @@ router.use('/user', userRouter);
 router.use('/friend', friendRouter);
 router.use('/emoticon', emoticonRouter);
 router.use('/goal', goalRouter);
+router.use('/calendar', calendarRouter);
 
 export default router;


### PR DESCRIPTION
## 요약
월 단위로 일별 태스크 존재 여부를 조회할 수 있는 API를 구현하였습니다.
- 요청 URL : `/calendar/task?year=${year}&month=${month}`
   - `year` : 조회하고 싶은 연도
   - `month` : 조회하고 싶은 달
   - method : `GET`
- 응답
   - `boolean[]` (존재 여부 배열)
      - 배열의 크기는 요청한 달의 일수입니다.
      - `배열의 0번 index = 1일의 정보`, ... , `배열의 30번 index = 31일의 정보`
   - 연도 및 달 미지정, 잘못된 달 입력 : `400`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 연도 및 달 미지정 요청, 잘못된 달 입력 요청
1. 연도 및 달 미지정 요청
2. `400` 코드와 함께 올바른 연도를 입력하라는 메시지가 반환되는 것을 확인
3. 달 미지정 요청
4. `400` 코드와 함께 올바른 달을 입력하라는 메시지가 반환되는 것을 확인
5. `month = 13` 입력 요청
6. `400` 코드와 함께 올바른 달을 입력하라는 메시지가 반환되는 것을 확인

[4d452b2c-b4c2-4f8c-897e-b1881318ca86.webm](https://user-images.githubusercontent.com/92143119/206084553-8fadca56-d83f-46f0-8b9f-3ccb36318860.webm)
### 일별 태스크 존재 여부 조회 요청
1. `/calendar/task?year=2022&month=12`를 통해 `2022/12`의 일별 태스크 존재 여부 조회 요청
7. 태스크가 존재하는 날짜의 값은 `true`, 존재하지 않는 날짜의 값은 `false`인 `boolean` 배열이 반환된 모습을 확인

[b3075099-e6ad-4cf1-a4ca-548700a90ccf.webm](https://user-images.githubusercontent.com/92143119/206084547-c46bc093-a081-4444-9c3b-8fb878add76a.webm)

## 작업 내용
1. 일별 태스크 존재 여부 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
8. 주소창에 `http://localhost:8000/api/v1/calendar/task?year=${year}&month=${month}`를 입력합니다.

## 관련 Task
- [5-4]