### PR TITLE
[BE] [71] 태스크 삭제 API 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -363,6 +363,7 @@ router.delete('/:task_idx', authenticateToken, async (req: AuthorizedRequest, re
     if (notExistTask) return res.status(404).json({ msg: '존재하지 않는 태스크예요.' });
 
     await executeSql('delete from task_label where task_idx = ?', [taskIdx]);
+    await executeSql('delete from task_social_action where task_idx = ?', [taskIdx]);
     await executeSql('delete from task where user_idx = ? and idx = ?', [userIdx, taskIdx]);
     res.sendStatus(200);
   } catch (error) {


### PR DESCRIPTION
## 요약
태스크 삭제 시 친구가 태스크에 이모티콘을 남긴 경우 삭제가 불가능한 버그를 수정하였습니다.
task_social_action의 데이터를 삭제하지 않아 발생한 문제였습니다.
요청 및 응답 등에 대한 변경 사항은 없습니다.

## 작동 화면
1. `/emoticon/task/161`을 통해 `idx = 161` 태스크에 이모티콘이 남겨진 것을 확인
2. `idx = 161` 태스크 삭제 요청
3. `/emoticon/task/161`을 통해 존재하지 않는 태스크라는 메시지를 확인하여 태스크 삭제가 이루어진 것을 확인

[2c824b19-a473-4ca9-a928-60c4567fa203.webm](https://user-images.githubusercontent.com/92143119/206129787-0ddc5185-4487-471e-9dda-43fe80460938.webm)

## 작업 내용
1. task_social_action을 삭제하지 않아 task 삭제가 불가능했던 버그 수정

## 테스트 방법
1. 로그인을 완료합니다.
2. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/goal/${goal_idx}', {
     method: 'DELETE',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
   });
   ```

## 관련 Task
- [71]