### PR TITLE
[BE] [65] 태스크 생성 요청 시 종료 시각이 시작 시각보다 앞설 경우 400 반환

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -195,6 +195,8 @@ router.post('/', authenticateToken, async (req: AuthorizedRequest, res) => {
 
   const { title, date, importance, startedAt, endedAt, lat, lng, location, isPublic, tagIdx, content, done, labels } = req.body;
 
+  if (startedAt > endedAt) return res.sendStatus(400);
+
   try {
     if (labels.length > 0) {
       let labelCheckSql = 'select idx from label where user_idx = ? and ';


### PR DESCRIPTION
## 요약
- 이제 13:00에 시작하고 11:00에 종료되는 태스크는 만들 수 없습니다.