### PR TITLE
[BE] [5-5] 일별 평균 목표 달성률 조회 API 구현

### DIFF
--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import { RowDataPacket } from 'mysql2';
+import { executeSql } from '../db';
+import { AuthorizedRequest } from '../types';
+import { authenticateToken } from '../utils/auth';
+
+const router = Router();
+
+router.get('/goal', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+
+  try {
+    Object.values(CalendarQueryKeys).forEach((key) => validate(key, req.query[key] as string));
+  } catch (error) {
+    return res.status(400).send({ msg: error.message });
+  }
+
+  const year = parseInt(req.query.year as string);
+  const month = parseInt(req.query.month as string);
+
+  const dateSearchFormat = `${year}-${month}-%`;
+  const lastDate = new Date(year, month, 0);
+  const lastDay = lastDate.getDate();
+
+  const result = Array.from({ length: lastDay }, () => 0);
+  try {
+    const taskLabelSql = 'select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where done = true and user_idx = ? and date like ?';
+    const currentAmountSql = 'cast(ifnull(sum(task_label.amount), 0) as unsigned)';
+    const dailyRateSql = `select date, case when over then (${currentAmountSql} / goal.amount) when ${currentAmountSql} > goal.amount then 0 else 1 end as rate from goal left join (${taskLabelSql}) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date like ? group by idx`;
+
+    const dailyAverageRate = (await executeSql(`select date_format(date, "%d") as date, avg(rate) as averageRate from (${dailyRateSql}) daily_rate group by date`, [userIdx, dateSearchFormat, userIdx, dateSearchFormat])) as RowDataPacket;
+    dailyAverageRate.forEach(({ date, averageRate }) => {
+      result[parseInt(date) - 1] = parseFloat(averageRate);
+    });
+
+    res.json(result);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -26,7 +26,7 @@ router.get('/goal', authenticateToken, async (req: AuthorizedRequest, res) => {
   try {
     const taskLabelSql = 'select label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where done = true and user_idx = ? and date like ?';
     const currentAmountSql = 'cast(ifnull(sum(task_label.amount), 0) as unsigned)';
-    const dailyRateSql = `select date, case when over then (${currentAmountSql} / goal.amount) when ${currentAmountSql} > goal.amount then 0 else 1 end as rate from goal left join (${taskLabelSql}) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date like ? group by idx`;
+    const dailyRateSql = `select date, case when over then if(${currentAmountSql} / goal.amount > 1, 1, ${currentAmountSql} / goal.amount) when ${currentAmountSql} > goal.amount then 0 else 1 end as rate from goal left join (${taskLabelSql}) task_label on goal.label_idx = task_label.label_idx where user_idx = ? and date like ? group by idx`;
 
     const dailyAverageRate = (await executeSql(`select date_format(date, "%d") as date, avg(rate) as averageRate from (${dailyRateSql}) daily_rate group by date`, [userIdx, dateSearchFormat, userIdx, dateSearchFormat])) as RowDataPacket;
     dailyAverageRate.forEach(({ date, averageRate }) => {


### PR DESCRIPTION
## 요약
월 단위로 일별 평균 목표 달성률을 조회할 수 있는 API를 구현하였습니다.

목표 달성률은 아래의 조건에 따라 계산하였습니다.
- 목표 달성률 범위 : 0 이상 1 이하
- 목표가 존재하지 않는 경우 : `0`
- 목표의 `over = true`인 경우 (설정한 값 이상의 목표를 달성해야 하는 경우)
   - `현재 값 / 목표 값`
   - 목표 값보다 높은 값을 달성한 경우 : `1`
- 목표의 `over = false`인 경우 (설정한 값을 넘지 않아야 하는 목표의 경우)
   - 설정한 값을 넘지 않은 경우 : `1`
   - 설정한 값을 넘은 경우 : `0`

해당 API의 요청 및 응답 정보입니다.

- 요청 URL : `/calendar/goal?year=${year}&month=${month}`
   - `year` : 조회하고 싶은 연도
   - `month` : 조회하고 싶은 달
   - method : `GET`
- 응답
   - `float[]` (평균 목표 달성률 배열)
      - 배열의 크기는 요청한 달의 일수입니다.
      - `배열의 0번 index = 1일의 정보`, ... , `배열의 30번 index = 31일의 정보`
   - 연도 및 달 미지정, 잘못된 달 입력 : `400`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
### 연도 및 달 미지정 요청, 잘못된 달 입력 요청
1. 연도 및 달 미지정 요청
2. `400` 코드와 함께 올바른 연도를 입력하라는 메시지가 반환되는 것을 확인
3. 달 미지정 요청
4. `400` 코드와 함께 올바른 달을 입력하라는 메시지가 반환되는 것을 확인
5. `month = 13` 입력 요청
6. `400` 코드와 함께 올바른 달을 입력하라는 메시지가 반환되는 것을 확인

[9efef0bd-e79a-4e58-8852-aadd885de55e.webm](https://user-images.githubusercontent.com/92143119/206135070-3cc864fe-078f-458c-b1f3-0173ac2d484e.webm)

### 일별 평균 목표 달성률 조회 요청
1. `/calendar/goal?year=2022&month=12`를 통해 `2022/12`의 일별 평균 목표 달성률 조회 요청
2. 일별 평균 목표 달성률 배열이 반환된 모습을 확인

[a7290b36-5db8-42ec-8ba9-6d055ca098ce.webm](https://user-images.githubusercontent.com/92143119/206134868-6f23a81e-6d33-4d38-a8a1-65436c1ccb71.webm)

## 작업 내용
1. 일별 평균 목표 달성률 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
9. 주소창에 `http://localhost:8000/api/v1/calendar/goal?year=${year}&month=${month}`를 입력합니다.

## 관련 Task
- [5-5]