### PR TITLE
[BE] [73] 태스크 수정 API 수정

### DIFF
--- a/server/src/api/task.ts
+++ b/server/src/api/task.ts
@@ -257,14 +257,17 @@ router.patch('/update/:task_idx', authenticateToken, async (req: AuthorizedReque
 
   try {
     Object.values(TaskBodyKeys).forEach((key) => {
-      if (!req.body[key]) return;
+      if (req.body[key] === undefined) return;
       if (key === TaskBodyKeys.date || key === TaskBodyKeys.done) return;
       if (!validate(key, req.body[key])) req.body[key] = TaskBodyDefaultValues[key];
 
       if (key === TaskBodyKeys.labels) return;
+
       if (updateValue.length > 0) updateSql += ',';
       updateSql += ` ${TaskColumnKeys[key]} = ? `;
-      updateValue.push(req.body[key]);
+
+      if (req.body[key] === null || req.body[key] === '') updateValue.push(null);
+      else updateValue.push(req.body[key]);
     });
     updateSql += 'where idx = ?';
     updateValue.push(taskIdx);


### PR DESCRIPTION
## 요약
태스크 수정 시 빈 문자열과 `null`에 대한 입력이 처리되지 않는 버그를 수정하였습니다.
입력된 값이 `undefined`인지 체크하는 과정에서 `!value`라는 조건을 사용하여 위의 값도 `undefined`와 똑같은 처리가 이루어져 발생한 문제였습니다.
해당 조건문을 `value === undefined`로 변경하여 해결하였습니다.
추가로 빈 문자열이 입력된 경우 `null`로 취급하여 처리하도록 수정하였습니다.

## 작동 화면
1. `idx = 14` 태스크에 대하여 `location = ''` 수정 요청
2. `/task?date=2022-12-01`을 통하여 빈 문자열이 `null`로 취급되어 정상적으로 수정된 것을 확인

[b72fb483-edb4-4af3-bdbb-df33505e20d6.webm](https://user-images.githubusercontent.com/92143119/206149277-2428db71-3182-45f0-96b6-a9e89e637d3c.webm)

## 작업 내용
1. 빈 문자열, null 입력 처리

## 테스트 방법
1. 로그인을 완료합니다.
3. 개발자 도구 콘솔에 아래의 명령어를 입력합니다.
   ```js
   fetch('http://localhost:8000/api/v1/task/${task_idx}', {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       ${수정하고 싶은 항목}: ${수정할 값}
     }),
   });
   ```

## 관련 Task
- [73]