### PR TITLE
[FE] [8-20] 목표 탭 Progress Bar 스타일 개선

### DIFF
--- a/client/src/components/MainContainer/GoalManager.style.ts
+++ b/client/src/components/MainContainer/GoalManager.style.ts
@@ -62,11 +62,11 @@ export const Wrap = styled.div<{ color: string }>`
 
 export const Wave = styled.div<{ percentage: number }>`
   position: absolute;
-  top: -13rem;
-  left: calc(-33rem + ${(props) => props.percentage * 11.5}rem);
+  top: -9rem;
+  left: calc(-20.9rem + ${(props) => props.percentage * 10.4}rem);
 
-  width: 31rem;
-  height: 31rem;
+  width: 20rem;
+  height: 20rem;
 
   background: linear-gradient(#a7a5e734, #99b1db34);
   border-radius: 44%;


### PR DESCRIPTION
## 요약
- Progress Bar가 과도하게 넘실대지 않게 조정했습니다.

## 작동 화면
[689bd606-1273-498d-bec3-da731a19466c.webm](https://user-images.githubusercontent.com/55306894/206155504-d19f066c-0712-46d9-b9b8-7da8214d904b.webm)
