### PR TITLE
[FE] [7-8] 테스크 수정 API 연결 및 모달 기능 구현

### DIFF
--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -171,7 +171,7 @@ const Log = () => {
     setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, [type]: isChecked });
   };
 
-  const handleEditModal = useEffect(() => {
+  useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseup', handleMouseUp);
     return () => {

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -119,9 +119,11 @@ const Log = () => {
     }
   };
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
 
   const handleCloseButtonClick = () => {
     setIsModalOpen(false);
+    setIsEditModalOpen(false);
     fetch();
   };
 
@@ -169,7 +171,7 @@ const Log = () => {
     setCompletionCheckBoxStatus({ ...completionCheckBoxStatus, [type]: isChecked });
   };
 
-  useEffect(() => {
+  const handleEditModal = useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseup', handleMouseUp);
     return () => {
@@ -219,7 +221,7 @@ const Log = () => {
                     <S.TagTitle color={tag.color} data-tag={tag.idx}>
                       #{tag.title}
                     </S.TagTitle>
-                    <TaskList taskList={getFilteredTaskListbyTag(tag.idx)} activeTask={activeTask} completionFilter={completionCheckBoxStatus} fetchTaskList={fetchTaskList} />
+                    <TaskList taskList={getFilteredTaskListbyTag(tag.idx)} activeTask={activeTask} completionFilter={completionCheckBoxStatus} fetchTaskList={fetchTaskList} setIsEditModalOpen={setIsEditModalOpen} />
                   </S.TagWrap>
                 );
             })}
@@ -227,8 +229,25 @@ const Log = () => {
           </S.LogMainSection>
           {currentVisit.isMe && <S.NewTaskButton onClick={() => setIsModalOpen(true)} />}
           {isModalOpen && (
-            <Modal component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} tagList={tagList} fetchTagList={fetchTagList} />} zIndex={1001} top="50%" left="50%" transform="translate(-50%, -50%)" handleDimmedClick={() => {}} />
-          )}        
+            <Modal
+              component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} tagList={tagList} fetchTagList={fetchTagList} currentTask={null} />}
+              zIndex={1001}
+              top="50%"
+              left="50%"
+              transform="translate(-50%, -50%)"
+              handleDimmedClick={() => {}}
+            />
+          )}
+          {isEditModalOpen && (
+            <Modal
+              component={<TaskModal handleCloseButtonClick={handleCloseButtonClick} tagList={tagList} fetchTagList={fetchTagList} currentTask={taskList.find((el) => el.idx === activeTask)!} />}
+              zIndex={1001}
+              top="50%"
+              left="50%"
+              transform="translate(-50%, -50%)"
+              handleDimmedClick={() => {}}
+            />
+          )}
         </S.Grid>
       </S.LogContainer>
     </>

--- a/client/src/components/MainContainer/TaskItem.tsx
+++ b/client/src/components/MainContainer/TaskItem.tsx
@@ -50,6 +50,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList, setIs
   };
   const DetailInfo = ({ task }: { task: Task }) => {
     //코멘트 조회
+    console.log(task);
 
     return (
       <>
@@ -84,7 +85,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList, setIs
             <S.TaskDetailInfos flex="row">
               {task.labels.map((label) => {
                 return (
-                  <S.LabelListItem key={label.title} color={label.color}>
+                  <S.LabelListItem key={label.labelIdx} color={label.color}>
                     {label.title} {label.amount} {label.unit}
                   </S.LabelListItem>
                 );

--- a/client/src/components/MainContainer/TaskItem.tsx
+++ b/client/src/components/MainContainer/TaskItem.tsx
@@ -1,19 +1,21 @@
 import axios from 'axios';
 import { Task, CompletionCheckBoxStatus } from 'GlobalType';
-import { useEffect } from 'react';
+import { useState } from 'react';
 import { HOST } from '../../constants';
 import * as S from './Log.style';
 import { visitState } from '../common/atoms';
 import { useRecoilState } from 'recoil';
+import TaskModal from '../TaskModal/TaskModal';
 
 interface taskListProps {
   taskList: Task[];
   activeTask: number | null;
   completionFilter: CompletionCheckBoxStatus;
   fetchTaskList: () => Promise<void>;
+  setIsEditModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: taskListProps) => {
+const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList, setIsEditModalOpen }: taskListProps) => {
   const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
 
   const isTaskFiltered = (done: boolean) => {
@@ -42,6 +44,10 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
     return count;
   };
 
+  const taskChange = (task: Task) => {
+    setIsEditModalOpen(true);
+    //modal...
+  };
   const DetailInfo = ({ task }: { task: Task }) => {
     //코멘트 조회
 
@@ -98,7 +104,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
                   완료
                 </S.TaskDetailIcon>
 
-                <S.TaskDetailIcon>
+                <S.TaskDetailIcon onClick={(e) => taskChange(task)}>
                   <S.EditIcon />
                   수정
                 </S.TaskDetailIcon>

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -35,7 +35,7 @@ const DEFAULT_IMPORTANCE = 3;
 const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask }: Props) => {
   const [tagIdx, setTagIdx] = useState<number | null>(currentTask ? currentTask.tagIdx : null);
   const [locationObject, setLocationObject] = useState<Location | null>(currentTask && currentTask?.location !== null && currentTask?.location !== '' ? { location: currentTask!.location, lng: currentTask!.lng, lat: currentTask!.lat } : null); // { location, lng, lat }
-  const [labelArray, setLabelArray] = useState<Label[]>(currentTask ? currentTask.labels : []);
+  const [labelArray, setLabelArray] = useState<Label[]>(currentTask ? currentTask.labels.map((d) => ({ idx: d.labelIdx, title: d.title, amount: d.amount, color: d.color, count: 999, unit: d.unit })) : []);
 
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
@@ -112,7 +112,6 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask 
   };
 
   const httpPatchTask = async (body: FieldValues) => {
-    console.log(body);
     await axios.patch(`${HOST}/api/v1/task/update/${currentTask!.idx}`, body);
   };
 

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -7,7 +7,7 @@ declare module 'GlobalType' {
   }
 
   interface LabelData {
-    idx: number;
+    labelIdx: number;
     title: string;
     color: string;
     amount: number;


### PR DESCRIPTION
## 요약
- 테스크 수정 API 연결을 진행했습니다.
- TaskModal에서의 수정 기능을 구현했습니다.

## 작동 화면
![Dec-07-2022 19-41-15](https://user-images.githubusercontent.com/73420533/206158051-1c66f798-8d29-4da4-8c7c-fd546443d83b.gif)
- 모든 요소가 수정 가능합니다. 위치와 라벨의 삭제도 가능합니다. 수정된 값은 바로 화면에 반영됩니다.

## 작업 내용
1. Log 컴포넌트의 isEditModalOpen 값으로 관리
2. TaskModal의 props으로 현재 열려있는 currentTask 정보를 전달합니다. 해당 값이 null인 경우 생성 모달로서, 해당 값이 존재하는 경우 수정 모달로서 기능하도록 분기 처리했습니다.
3. LabelData 인터페이스 내 인덱스 값이 labelIdx가 아닌 idx로 설정되어 있던 문제를 수정했습니다.
4. 라벨 생성 시의 isPublic 기본값을 true로 변경했습니다.

## 관련 Task
- 7-8

