### PR TITLE
[FE/BE] [6-3] Diary 초기 도형 로딩 동기화

### DIFF
--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { visitState } from '../common/atoms';
+import useCurrentDate from '../../hooks/useCurrentDate';
 import globalSocket from '../common/Socket';
 import { DEFAULT_OBJECT_VALUE } from '../../constants';
 import { Shape, FabricText, FabricLine, ShapeType, FabricObject, ObjectData } from 'GlobalType';
@@ -9,6 +12,8 @@ import styled from 'styled-components';
 const Canvas = () => {
   const canvasRef = useRef<fabric.Canvas | null>(null);
   const colorRef = useRef<HTMLInputElement | null>(null);
+  const currentVisit = useRecoilValue(visitState);
+  const { currentDate, dateToString } = useCurrentDate();
   const canvasBackground = '/canvasBackground.png';
   const diaryObjects = new Map();
 
@@ -259,6 +264,11 @@ const Canvas = () => {
     globalSocket.emit('sendModifiedObject', objectData);
   };
 
+  const joinSocketRoom = () => {
+    const currentDateString = dateToString();
+    globalSocket.emit('joinToNewRoom', currentVisit.userId, currentDateString);
+  };
+
   const presentPresetObjects = (objectDataMap: ObjectData) => {
     Object.values(objectDataMap).forEach((objectData) => {
       updateModifiedObject(objectData);
@@ -275,8 +285,12 @@ const Canvas = () => {
       img.setCoords();
       if (!canvasRef.current) return;
       canvasRef.current.add(img);
-      globalSocket.emit('requestCurrentObjects');
+      joinSocketRoom();
     });
+  };
+
+  const requestInitObjects = () => {
+    globalSocket.emit('requestCurrentObjects');
   };
 
   useEffect(() => {
@@ -287,6 +301,7 @@ const Canvas = () => {
     globalSocket.on('offerCurrentObjects', presentPresetObjects);
     globalSocket.on('updateModifiedObject', updateModifiedObject);
     globalSocket.on('applyObjectRemoving', removeObject);
+    globalSocket.on('initReady', requestInitObjects);
     window.addEventListener('keydown', handleKeydown);
 
     return () => {
@@ -296,7 +311,9 @@ const Canvas = () => {
       globalSocket.off('offerCurrentObjects', presentPresetObjects);
       globalSocket.off('updateModifiedObject', updateModifiedObject);
       globalSocket.off('applyObjectRemoving', removeObject);
+      globalSocket.off('initReady', requestInitObjects);
       window.removeEventListener('keydown', handleKeydown);
+      globalSocket.emit('leaveCurrentRoom', currentVisit.userId, dateToString());
       canvasRef.current.clear();
     };
   });

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,23 +1,12 @@
-import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { visitState } from '../common/atoms';
-import globalSocket from '../common/Socket';
 import Canvas from './Canvas';
 import * as S from './Diary.style';
 import DateSelector from './DateSelector';
-import useCurrentDate from '../../hooks/useCurrentDate';
 
 const Diary = () => {
   const currentVisit = useRecoilValue(visitState);
-  const { currentDate, dateToString } = useCurrentDate();
 
-  useEffect(() => {
-    const currentDateString = dateToString();
-    globalSocket.emit('joinToNewRoom', currentVisit.userId, currentDateString);
-    return () => {
-      globalSocket.emit('leaveCurrentRoom', currentVisit.userId, currentDateString);
-    };
-  }, [currentVisit, currentDate]);
   return (
     <>
       <S.DiaryTitle>

--- a/client/src/components/common/Socket.ts
+++ b/client/src/components/common/Socket.ts
@@ -6,6 +6,7 @@ interface ServerToClientEvents {
   updateModifiedObject: (objectData: FabricLine | FabricText | Shape) => void;
   applyObjectRemoving: (objectId: string) => void;
   offerCurrentObjects: (objectDataMap: ObjectData) => void;
+  initReady: () => void;
 }
 
 interface ClientToServerEvents {

--- a/server/app.ts
+++ b/server/app.ts
@@ -107,13 +107,17 @@ io.on('connection', (socket: AuthorizedSocket) => {
     socket.join(roomName);
     if (io.sockets.adapter.rooms.get(roomName).size === 1) {
       const diaryData = (await getDiary(roomName)) || {};
+      console.log(roomName, diaryData);
       diaryObjects[roomName] = diaryData;
+      io.to(socket.id).emit('initReady');
+    } else {
+      io.to(socket.id).emit('initReady');
     }
-    io.to(socket.id).emit('initReady');
   });
   socket.on('leaveCurrentRoom', async (destId, date) => {
     const roomName = destId + date;
     socket.leave(roomName);
+    console.log(io.sockets.adapter.rooms.get(roomName));
     if (!io.sockets.adapter.rooms.get(roomName)) {
       const diaryData = diaryObjects[roomName] || {};
       await setDiary(roomName, diaryData);

--- a/server/app.ts
+++ b/server/app.ts
@@ -63,6 +63,7 @@ io.on('connection', (socket) => {
       const diaryData = (await getDiary(roomName)) || {};
       diaryObjects[roomName] = diaryData;
     }
+    io.to(socket.id).emit('initReady');
   });
   socket.on('leaveCurrentRoom', async (destId, date) => {
     const roomName = destId + date;


### PR DESCRIPTION
## 요약
배경로딩, Socket Room join, 현재 존재하는 도형 loading 순서를 동기화했습니다.

## 작동 화면
없다면 생략

## 작업 내용
1. 이제 다이어리탭에 진입하면 제일 먼저 배경화면을 불러옵니다
2. 배경화면 로딩이 끝나면 소켓 Room에 진입합니다
3. 소켓Room에 진입하면 클라이언트에 완료신호를 보냅니다
4. 클라이언트는 신호를 받으면 초기 도형 정보를 요청합니다

## 테스트 방법
1.

## 관련 Task
-[6-3]

## 비고
