### PR TITLE
[FE] [4-12] 친구 우클릭메뉴 프로필조회 구현

### DIFF
--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -45,7 +45,7 @@ export const ProfileBox = styled.div<{
 `;
 
 export const FriendMenuModal = styled.div`
-  height: 3.5rem;
+  height: 4rem;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
@@ -85,10 +85,38 @@ export const FriendMenuModal = styled.div`
 
 export const FriendMenuModalItem = styled.div`
   color: var(--color-main);
-  font-size: 0.75rem;
+  font-size: 1rem;
   cursor: pointer;
   &:hover {
     font-weight: 700;
     color: #505bf0;
   }
 `;
+
+export const FriendProfileContainer=styled.div`
+width: 31rem;
+height: 13rem;
+border-radius: 1rem;
+background: white;
+display: flex;
+justify-content:center;
+align-items: center;
+`
+export const FriendProfileInfo = styled.div`
+width: 15rem;
+display: flex;
+flex-direction: column;
+justify-content: center;
+gap: 0.75rem;
+`
+export const FriendProfileName = styled.span`
+  font-size: 1.5rem;
+  font-family: 'Noto Sans KR', sans-serif;
+`
+
+export const FriendProfileId = styled.span`
+margin-bottom: 2rem;
+  color: #707070;
+  font-size: 1rem;
+  font-family: 'Noto Sans KR', sans-serif;
+`

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -3,6 +3,9 @@ import { useRecoilState } from 'recoil';
 import { Friend } from 'GlobalType';
 import * as S from './FriendsBar.style';
 import { visitState } from '../common/atoms';
+import Modal from '../common/Modal';
+import {MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM, HOST} from '../../constants/index'
+import {ProfileImage} from '../Drawer/Drawer.style'
 
 interface FriendsBarProps {
   myProfile: Friend | null;
@@ -13,10 +16,19 @@ interface ProfileBoxProps {
   userId: string;
   profileImg: string;
 }
+interface FriendMenuModalProps{
+  setIsFriendProfileOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+interface FriendProfileModalProps{
+  userId: string;
+  username:string;
+  profileImg:string;
+}
 
 const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
   const [friendMenuId, setFriendMenuId] = useState<string | null>(null);
+  const [isFriendProfileOpen, setIsFriendProfileOpen] = useState(false)
 
   const ProfileBox = ({ userId, profileImg }: ProfileBoxProps) => {
     const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
@@ -42,11 +54,16 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
             onContextMenu={(e) => handleRightClick(e, userId)}
             nowVisiting={currentVisit.userId === userId}
           ></S.ProfileBox>
-          {friendMenuId === userId && userId !== myProfile?.userId && <FriendMenuModal></FriendMenuModal>}
+          {friendMenuId === userId && userId !== myProfile?.userId && <FriendMenuModal setIsFriendProfileOpen={setIsFriendProfileOpen}></FriendMenuModal>}
         </div>
       </>
     );
   };
+
+  const closeFriendProfileModal = (e:React.MouseEvent)=>{
+    e.stopPropagation();
+    setIsFriendProfileOpen(false)
+  }
 
   return (
     <>
@@ -58,19 +75,40 @@ const FriendsBar = ({ myProfile, friendsList, handlePlusButtonClick }: FriendsBa
           })}
         <S.ProfileBox userId={'친구 추가'} imgURL={plusIcon} onClick={handlePlusButtonClick}></S.ProfileBox>
       </S.FriendsBarContainer>
-    </>
+      {isFriendProfileOpen&&
+      friendsList?.filter(({userId})=>userId===friendMenuId)
+      .map(({userId, username, profileImg})=>{
+        return <Modal key={'profile'+userId} component={<FriendProfileModal userId={userId} username={username} profileImg={profileImg}/>} top={MODAL_CENTER_TOP} left={MODAL_CENTER_LEFT} transform={MODAL_CENTER_TRANSFORM} zIndex={1000} handleDimmedClick={(e) => closeFriendProfileModal(e)} />
+      })}
+      </>
   );
 };
 
 export default FriendsBar;
 
-const FriendMenuModal = () => {
+const FriendMenuModal = ({setIsFriendProfileOpen}:FriendMenuModalProps) => {
+  const openFriendProfile = (e:React.MouseEvent)=>{
+    e.stopPropagation()
+    setIsFriendProfileOpen(true)
+  }
   return (
     <>
       <S.FriendMenuModal>
-        <S.FriendMenuModalItem>프로필보기</S.FriendMenuModalItem>
+        <S.FriendMenuModalItem onClick={(e)=>openFriendProfile(e)}>프로필보기</S.FriendMenuModalItem>
         <S.FriendMenuModalItem>삭제하기</S.FriendMenuModalItem>
       </S.FriendMenuModal>
     </>
   );
 };
+
+const FriendProfileModal=({userId, username, profileImg}:FriendProfileModalProps)=>{
+  return (
+    <S.FriendProfileContainer>
+      <ProfileImage padding="2rem" size="10rem" src={HOST + '/' + profileImg}></ProfileImage>
+    <S.FriendProfileInfo>
+      <S.FriendProfileName><strong>{username}</strong>님</S.FriendProfileName>
+      <S.FriendProfileId>@{userId}</S.FriendProfileId>
+    </S.FriendProfileInfo>
+    </S.FriendProfileContainer>
+  )
+}


### PR DESCRIPTION
## 요약
친구 메뉴를 통해 프로필 조회가 가능합니다

## 작동 화면
![친구프로필조회](https://user-images.githubusercontent.com/109147404/206201467-cbe7acc8-d5cc-47c2-9c71-6215e6973d44.gif)

## 작업 내용
1. 친구 프로필사진을 우클릭하면 메뉴모달이 나타납니다.
2. 메뉴에서 프로필보기를 클릭하면 친구의 프로필을 조회할 수 있습니다.

## 테스트 방법
1. 친구프로필사진에서 우클릭으로 메뉴가 나타나는지 확인합니다.
2. 메뉴에서 프로필보기를 클릭하여 올바른 프로필이 나타나는지 확인합니다.

## 관련 Task
-[4-12]

## 비고
