### PR TITLE
[FE] [5-1] LOG, GOAL 탭 캘린더 API 연결 / 메뉴 셀렉터 로직 수정

### DIFF
--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
-import { visitState } from '../common/atoms';
+import { useRecoilState } from 'recoil';
+import { menuState, visitState } from '../common/atoms';
 import globalSocket from '../common/Socket';
 import Canvas from './Canvas';
 import * as S from './Diary.style';
@@ -8,7 +8,9 @@ import DateSelector from './DateSelector';
 import useCurrentDate from '../../hooks/useCurrentDate';
 
 const Diary = () => {
-  const currentVisit = useRecoilValue(visitState);
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+  const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
+
   const { currentDate, dateToString } = useCurrentDate();
 
   useEffect(() => {
@@ -18,6 +20,11 @@ const Diary = () => {
       globalSocket.emit('leaveCurrentRoom', currentVisit.userId, currentDateString);
     };
   }, [currentVisit, currentDate]);
+
+  useEffect(() => {
+    setCurrentMenu('DIARY');
+  }, []);
+
   return (
     <>
       <S.DiaryTitle>

--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -10,6 +10,8 @@ import { FieldValues, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import useCurrentDate from '../../hooks/useCurrentDate';
+import { menuState } from '../common/atoms';
+import { useRecoilState } from 'recoil';
 
 const httpGetGoalList = async (dateString: string) => {
   const response = await axios.get(`${HOST}/api/v1/goal?date=${dateString}`);
@@ -29,6 +31,8 @@ const GoalManager = () => {
   const [isLabelModalOpen, setIsLabelModalOpen] = useState(false);
   const { dateToString } = useCurrentDate();
   const [goalList, setGoalList] = useState<Goal[]>([]);
+
+  const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
 
   const fetchLabelMap = async () => {
     try {
@@ -66,6 +70,10 @@ const GoalManager = () => {
   const handleCloseButtonClick = () => {
     setIsGoalModalOpen(false);
   };
+
+  useEffect(() => {
+    setCurrentMenu('GOAL');
+  }, []);
 
   return (
     <>

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -9,7 +9,7 @@ import useCurrentDate from '../../hooks/useCurrentDate';
 import Modal from '../common/Modal';
 import TaskModal from '../TaskModal/TaskModal';
 import { useRecoilState } from 'recoil';
-import { visitState } from '../common/atoms';
+import { menuState, visitState } from '../common/atoms';
 
 interface Tag {
   idx: number;
@@ -177,6 +177,11 @@ const Log = () => {
     };
   });
 
+  const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
+
+  useEffect(() => {
+    setCurrentMenu('LOG');
+  }, []);
   return (
     <>
       {selectedTask !== null && (

--- a/client/src/components/MainContainer/MenuSelector.tsx
+++ b/client/src/components/MainContainer/MenuSelector.tsx
@@ -22,7 +22,7 @@ const MenuSelector = () => {
     <S.MenuSelector>
       {Menus.map((menu) => {
         return (
-          <S.MenuButton data-menu={menu} onClick={handleMenuClick} isActivatedMenu={menu === currentMenu}>
+          <S.MenuButton key={menu} data-menu={menu} onClick={handleMenuClick} isActivatedMenu={menu === currentMenu}>
             {menu}
           </S.MenuButton>
         );

--- a/client/src/components/MainContainer/MenuSelector.tsx
+++ b/client/src/components/MainContainer/MenuSelector.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Menus, RoutePath } from '../../constants';
+import { menuState } from '../common/atoms';
+import { useRecoilState } from 'recoil';
 import * as S from './Calendar.style';
 
 const MenuSelector = () => {
-  const [selectedMenu, setSelectedMenu] = useState('LOG');
+  const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
+
   const navigate = useNavigate();
   const handleMenuClick = (e: React.MouseEvent) => {
     const target = e.target;
     if (!(target instanceof HTMLDivElement)) return;
     const selectedMenu = target.dataset.menu;
     if (selectedMenu) {
-      setSelectedMenu(selectedMenu);
       navigate(RoutePath[selectedMenu]);
     }
   };
@@ -20,7 +22,7 @@ const MenuSelector = () => {
     <S.MenuSelector>
       {Menus.map((menu) => {
         return (
-          <S.MenuButton data-menu={menu} onClick={handleMenuClick} isActivatedMenu={menu === selectedMenu}>
+          <S.MenuButton data-menu={menu} onClick={handleMenuClick} isActivatedMenu={menu === currentMenu}>
             {menu}
           </S.MenuButton>
         );

--- a/client/src/components/MainContainer/TaskItem.tsx
+++ b/client/src/components/MainContainer/TaskItem.tsx
@@ -118,7 +118,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
       {taskList.map((task: Task) => {
         return (
           !isTaskFiltered(task.done) && (
-            <>
+            <div key={task.idx}>
               <S.TaskItem key={'task' + task.idx} data-idx={task.idx} data-tag={task.tagIdx} data-active={task.idx === activeTask} done={Number(task.done)} cols={CalcHeight(task)}>
                 <S.TaskMainInfos>
                   <S.TaskTime>{task.startedAt}</S.TaskTime>
@@ -128,7 +128,7 @@ const TaskList = ({ taskList, activeTask, completionFilter, fetchTaskList }: tas
                 {task.idx === activeTask && <DetailInfo task={task} />}
               </S.TaskItem>
               {task.idx === activeTask && <EmoticonList key={task.idx} task={task} isMe={currentVisit.isMe} />}
-            </>
+            </div>
           )
         );
       })}
@@ -174,7 +174,9 @@ const EmoticonList = ({ task, isMe }: { task: Task; isMe: boolean }) => {
       {!isMe && (
         <S.EmoticonInput>
           {emoticonSample.map((el, index) => (
-            <span onClick={(e) => postEmoticon(index)}>{el}</span>
+            <span key={index} onClick={(e) => postEmoticon(index)}>
+              {el}
+            </span>
           ))}
         </S.EmoticonInput>
       )}

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -8,3 +8,7 @@ export const visitState = atom({
   key: 'currentVisiting',
   default: { userId: '', isMe: true },
 });
+export const menuState = atom({
+  key: 'currentMenu',
+  default: 'LOG',
+});


### PR DESCRIPTION
## 요약
- LOG GOAL 탭 캘린더 API 를 연결했습니다
- url 이동으로 화면 전환 시 메뉴 셀렉터가 수정되지 않는 문제를 해결했습니다.

## 작동 화면
![Dec-08-2022 15-15-38](https://user-images.githubusercontent.com/73420533/206372227-ca31d5ca-611f-4667-8a5f-a5d72c7c62d7.gif)
- 연결된 달력을 확인할 수 있습니다.

![Dec-08-2022 15-15-51](https://user-images.githubusercontent.com/73420533/206372305-f379d7b7-3a9d-4027-be32-0a9009b7af99.gif)
- 이제 어떤 방법으로 탭 이동시에도 메뉴 셀렉터가 올바르게 작동합니다.

## 작업 내용
1. API 연결
2. 메뉴 셀렉터 값을 전역 변수로 관리합니다

## 관련 Task
5-1.
38.

## 비고
- 목표 달력 API 오류가 발견되었습니다.
- Task 생성 시에 달력이 갱신되는 로직을 개선 중입니다.
