### PR TITLE
[FE] [17] 회원가입 페이지 디자인 조정

### DIFF
--- a/client/src/components/MainContainer/Calendar.style.ts
+++ b/client/src/components/MainContainer/Calendar.style.ts
@@ -8,7 +8,7 @@ export const CalendarTitle = styled.span`
   font-size: 1.7rem;
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
-  z-index: -1;
+  z-index: 1;
 `;
 export const CalendarContainer = styled.div`
   width: 100%;

--- a/client/src/components/SignupMenu/SignupMenu.style.ts
+++ b/client/src/components/SignupMenu/SignupMenu.style.ts
@@ -9,7 +9,7 @@ export const Container = styled.div`
 `;
 export const SignupContainer = styled.div`
   width: 39rem;
-  height: 39rem;
+  height: 43rem;
   background: white;
   border: 1px solid var(--color-gray1);
   display: flex;

--- a/client/src/components/SignupMenu/SignupMenu.tsx
+++ b/client/src/components/SignupMenu/SignupMenu.tsx
@@ -78,13 +78,13 @@ const SignupMenu = () => {
             </S.EditRound>
           </S.ProfileImage>
           <S.InputBar {...register('userId')} placeholder="ID" />
-          <h3>{errors.userId?.message as string}</h3>
+          {errors.userId && <h3>{errors.userId?.message as string}</h3>}
           <S.InputBar {...register('password')} placeholder="PASSWORD" type="password" />
-          <h3>{errors.password?.message as string}</h3>
+          {errors.password && <h3>{errors.password?.message as string}</h3>}
           <S.InputBar {...register('confirmPassword')} placeholder="PASSWORD" type="password" />
-          <h3>{errors.confirmPassword?.message as string}</h3>
+          {errors.confirmPassword && <h3>{errors.confirmPassword?.message as string}</h3>}
           <S.InputBar {...register('username')} placeholder="NICKNAME" />
-          <h3>{errors.username?.message as string}</h3>
+          {errors.username && <h3>{errors.username?.message as string}</h3>}
 
           <h3>{messageFromServer}</h3>
           <S.SignupButton>SIGN UP</S.SignupButton>

--- a/client/src/components/TopBar/Clock/Clock.style.ts
+++ b/client/src/components/TopBar/Clock/Clock.style.ts
@@ -6,4 +6,5 @@ export const DigitalClock = styled.span`
   font-family: 'Baumans', cursive;
   align-self: flex-end;
   transform: translateY(0.3rem);
+  z-index: 1;
 `;

--- a/client/src/components/TopBar/TopBar.style.ts
+++ b/client/src/components/TopBar/TopBar.style.ts
@@ -18,6 +18,7 @@ export const MainTitle = styled.div`
   color: white;
   font-size: 5.5rem;
   font-family: 'Baumans', cursive;
+  z-index: 1;
 `;
 
 export const MenuIcon = styled.img`


### PR DESCRIPTION
## 요약
- 회원가입 페이지가 짤리는 문제를 해결했습니다.
- 컴포넌트 타이틀이 그림자 뒤에 보이는 문제를 해결했습니다.

## 작동 화면
![Dec-08-2022 15-53-53](https://user-images.githubusercontent.com/73420533/206379009-97945cb2-f3ab-435b-ae6f-ae7af7bfeea3.gif)
- 에러가 발생할 경우에만 상황에 따라 적절하게 늘어납니다.

<br>

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/73420533/206378776-8d1bcefe-dbe5-4474-9256-86f89b179a9a.png">
- 타이틀이 정상적으로 표시됩니다.
- 아마 drawer 클릭시 dimm보다 타이틀이 위에 보이는 문제 때문에 z-index를 수정해주신 것 같은데 dimm보다 아래에 표시되도록 수정했습니다.

## 관련 Task
17

