### PR TITLE
[FE] [84] 목표 생성 요청 body에 무조건 over: true가 담기는 문제 해결

### DIFF
--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -153,7 +153,7 @@ const GoalModal = ({ isLabelModalOpen, setIsLabelModalOpen, handleCloseButtonCli
   const setValues = () => {
     setValue('date', dateToString());
     if (typeof selectedLabelIndex === 'number') setValue('labelIdx', selectedLabelIndex);
-    if (over) setValue('over', over);
+    if (over !== undefined) setValue('over', over);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 요약
- `over`가 `false`일 때 body에 제대로 반영이 되지 않던 문제를 해결했습니다.