### PR TITLE
[FE] [5-1] 캘린더 타이밍 오류 수정

### DIFF
--- a/client/src/components/MainContainer/Calendar.tsx
+++ b/client/src/components/MainContainer/Calendar.tsx
@@ -49,7 +49,7 @@ const Calendar = () => {
   const [calendarPercent, setCalendarPercent] = useState([]);
 
   useEffect(() => {
-    const getEmoticon = async () => {
+    const getCalendarData = async () => {
       try {
         if (currentMenu == 'LOG' || currentMenu == 'MAP' || currentMenu == 'DIARY') {
           const result = await axios.get(`${HOST}/api/v1/calendar/task?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
@@ -62,7 +62,7 @@ const Calendar = () => {
         console.log(error);
       }
     };
-    getEmoticon();
+    getCalendarData();
   }, [calendarDate.getMonth(), currentMenu]);
 
   return (

--- a/client/src/components/MainContainer/Map.tsx
+++ b/client/src/components/MainContainer/Map.tsx
@@ -80,10 +80,6 @@ export const Map = () => {
     };
   }, [taskList]);
 
-  useEffect(() => {
-    setCurrentMenu('MAP');
-  }, []);
-
   const ValidTaskList = () => {
     const focusSelectedTask = (lat: number, lng: number) => {
       const focusPosition = new kakao.maps.LatLng(lat, lng);

--- a/client/src/components/MainContainer/Map.tsx
+++ b/client/src/components/MainContainer/Map.tsx
@@ -80,6 +80,10 @@ export const Map = () => {
     };
   }, [taskList]);
 
+  useEffect(() => {
+    setCurrentMenu('MAP');
+  }, []);
+
   const ValidTaskList = () => {
     const focusSelectedTask = (lat: number, lng: number) => {
       const focusPosition = new kakao.maps.LatLng(lat, lng);

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -10,5 +10,5 @@ export const visitState = atom({
 });
 export const menuState = atom({
   key: 'currentMenu',
-  default: 'LOG',
+  default: '',
 });


### PR DESCRIPTION
## 요약
- MAP 탭 캘린더 연결은 #187 에서 해주셨네요 ㅎㅎ
- LOG 외의 탭 접근 시 잘못 표시될 때가 있는 문제를 해결했습니다.

## 작동 화면
![Dec-08-2022 23-10-42](https://user-images.githubusercontent.com/73420533/206467673-4d94a16f-c25a-4895-ac54-5fc2049ccd1b.gif)
- 새로고침 시에도 올바르게 표시됨
- 맵 탭에서는 테스크 존재 여부를 표시함

## 관련 Task
- 5-1

## 비고
- 다이어리 캘린더는 레디스로 확인해야 돼서 제가 연결하지 못했습니답,,