### PR TITLE
[FE] [4-2] 프로필 수정 API 연결

### DIFF
--- a/client/src/components/Drawer/Drawer.style.ts
+++ b/client/src/components/Drawer/Drawer.style.ts
@@ -1,3 +1,4 @@
+import { BsFillCameraFill } from 'react-icons/bs';
 import styled from 'styled-components';
 
 // 최상위 레이아웃
@@ -55,12 +56,15 @@ export const Username = styled.span`
 `;
 
 export const UserId = styled.span`
-  color: #707070;
-  font-size: 0.9rem;
+  color: var(--color-gray6);
+  font-size: 1rem;
+  line-height: 3rem;
 `;
 
 export const SizedText = styled.span<{ fontSize: string }>`
   font-size: ${(props) => props.fontSize};
+  display: flex;
+  align-items: center;
 `;
 
 export const ProfileImage = styled.img<{ size?: string; padding?: string }>`
@@ -83,8 +87,8 @@ export const ProfileEditButton = styled.a`
   margin-left: auto;
 `;
 
-const PROFILE_EDIT_FORM_WIDTH = '40rem';
-const PROFILE_EDIT_FORM_HEIGHT = '30rem';
+const PROFILE_EDIT_FORM_WIDTH = '35rem';
+const PROFILE_EDIT_FORM_HEIGHT = '20rem';
 export const PROFILE_EDIT_FORM_Z_INDEX = 1001;
 export const PROFILE_EDIT_FORM_TOP = '50%';
 export const PROFILE_EDIT_FORM_LEFT = '50%';
@@ -95,7 +99,9 @@ export const ProfileEditForm = styled.div`
   background-color: white;
   width: ${PROFILE_EDIT_FORM_WIDTH};
   height: ${PROFILE_EDIT_FORM_HEIGHT};
-  border-radius: 20px;
+  border-radius: 30px;
+  justify-content: center;
+  align-items: center;
 `;
 
 export const ProfileMessageSection = styled.div`
@@ -106,12 +112,77 @@ export const ProfileMessageSection = styled.div`
   margin: 0 3rem;
 `;
 
-export const ProfileEditApplyButton = styled.div`
-  margin-top: auto;
-  margin-left: auto;
-  padding: 2rem;
-  padding-right: 3rem;
-  color: #bbbbbb;
+export const ProfileImageForm = styled.div`
+  width: 140px;
+  position: relative;
+  margin: auto;
+  img {
+    border: 6px solid var(--color-gray1);
+    height: 10rem;
+    width: 10rem;
+    object-fit: cover;
+    border-radius: 10rem;
+  }
+  margin: 30px 80px 30px 30px;
+`;
+
+export const EditRound = styled.div`
+  position: absolute;
+  bottom: 10px;
+  right: -30px;
+  background: var(--color-main);
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  input[type='file'] {
+    position: absolute;
+    transform: scale(2);
+    opacity: 0;
+    cursor: pointer;
+  }
+`;
+
+export const EditIcon = styled(BsFillCameraFill)`
+  width: 1.4rem;
+  height: 1.4rem;
+  display: block;
+  color: white;
+`;
+
+export const InputBar = styled.input`
+  background: var(--color-gray0);
+  border: 1px solid var(--color-gray3);
+  border-radius: 8px;
+  color: black;
+  width: 10rem;
+  margin: 5px 10px 5px 0px;
+  height: 2.3rem;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  padding-left: 1rem;
+
+  ::placeholder {
+    font-size: 0.8rem;
+    color: #a3a3a3;
+  }
+`;
+
+export const ProfileEditApplyButton = styled.div<{ isDone: boolean }>`
+  width: 18.5rem;
+  height: 2rem;
+  border: none;
+  border-radius: 1rem;
+  color: white;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 0.875rem;
+  text-align: center;
+  line-height: 2rem;
+  margin-bottom: 30px;
+  cursor: pointer;
+  background: ${(props) => (props.isDone ? 'var(--color-gray3)' : 'var(--color-main)')};
 `;
 
 // 프로필 영역

--- a/client/src/components/Drawer/Drawer.style.ts
+++ b/client/src/components/Drawer/Drawer.style.ts
@@ -93,7 +93,7 @@ export const PROFILE_EDIT_FORM_Z_INDEX = 1001;
 export const PROFILE_EDIT_FORM_TOP = '50%';
 export const PROFILE_EDIT_FORM_LEFT = '50%';
 export const PROFILE_EDIT_FORM_TRANFORM = 'translate(-50%, -50%)';
-export const ProfileEditForm = styled.div`
+export const ProfileEditForm = styled.form`
   display: flex;
   flex-direction: column;
   background-color: white;
@@ -170,7 +170,7 @@ export const InputBar = styled.input`
   }
 `;
 
-export const ProfileEditApplyButton = styled.div<{ isDone: boolean }>`
+export const ProfileEditApplyButton = styled.button<{ isDone: boolean }>`
   width: 18.5rem;
   height: 2rem;
   border: none;

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -51,7 +51,7 @@ const Drawer = ({ isOpen, myProfile, friendRequests, handleFriendRequests, handl
       </S.Drawer>
       {isProfileEditModalOpen && (
         <Modal
-          component={<ProfileEditForm myProfile={myProfile!} />}
+          component={<ProfileEditForm myProfile={myProfile!} setIsProfileEditModalOpen={setIsProfileEditModalOpen} />}
           top={PROFILE_EDIT_FORM_TOP}
           left={PROFILE_EDIT_FORM_LEFT}
           transform={PROFILE_EDIT_FORM_TRANFORM}
@@ -63,7 +63,7 @@ const Drawer = ({ isOpen, myProfile, friendRequests, handleFriendRequests, handl
   );
 };
 
-const ProfileEditForm = ({ myProfile }: { myProfile: Friend }) => {
+const ProfileEditForm = ({ myProfile, setIsProfileEditModalOpen }: { myProfile: Friend; setIsProfileEditModalOpen: React.Dispatch<React.SetStateAction<boolean>> }) => {
   //api 연결
   const [profileImg, setProfileImg] = useState<File | null>(null);
   const [username, onUsernameChange, setUsername] = useInput(myProfile.username);
@@ -74,11 +74,23 @@ const ProfileEditForm = ({ myProfile }: { myProfile: Friend }) => {
     }
   };
 
-  const postProfileChange = () => {
-    const formData = new FormData();
-    formData.append('username', username);
-    if (profileImg) formData.append('profileImg', profileImg);
-    //axios
+  const postProfileChange = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (username === '') return;
+    const profileFormData = new FormData();
+    profileFormData.append('username', username);
+    if (profileImg) profileFormData.append('profileImg', profileImg);
+    try {
+      await fetch(`${HOST}/api/v1/user/me`, {
+        method: 'PATCH',
+        credentials: 'include',
+        body: profileFormData,
+      }).then((res) => {
+        if (res.status == 200) setIsProfileEditModalOpen(false);
+      });
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   return (
@@ -98,7 +110,9 @@ const ProfileEditForm = ({ myProfile }: { myProfile: Friend }) => {
           <S.UserId>@{myProfile.userId}</S.UserId>
         </S.ProfileInfo>
       </S.Profile>
-      <S.ProfileEditApplyButton isDone={true}>PROFILE CHANGE</S.ProfileEditApplyButton>
+      <S.ProfileEditApplyButton type="submit" isDone={username === ''}>
+        PROFILE CHANGE
+      </S.ProfileEditApplyButton>
     </S.ProfileEditForm>
   );
 };

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -81,13 +81,12 @@ const ProfileEditForm = ({ myProfile, setIsProfileEditModalOpen }: { myProfile: 
     profileFormData.append('username', username);
     if (profileImg) profileFormData.append('profileImg', profileImg);
     try {
-      await fetch(`${HOST}/api/v1/user/me`, {
+      const response = await fetch(`${HOST}/api/v1/user/me`, {
         method: 'PATCH',
         credentials: 'include',
         body: profileFormData,
-      }).then((res) => {
-        if (res.status == 200) setIsProfileEditModalOpen(false);
       });
+      if (response.status == 200) setIsProfileEditModalOpen(false);
     } catch (error) {
       console.log(error);
     }

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -5,6 +5,7 @@ import { FRIEND_REQUEST_ACTION, HOST } from '../../constants';
 import Modal from '../common/Modal';
 import { Friend } from 'GlobalType';
 import * as S from './Drawer.style';
+import useInput from '../../hooks/useInput';
 
 interface DrawerProps {
   isOpen: boolean;
@@ -49,29 +50,55 @@ const Drawer = ({ isOpen, myProfile, friendRequests, handleFriendRequests, handl
         </S.LogoutButton>
       </S.Drawer>
       {isProfileEditModalOpen && (
-        <Modal component={<ProfileEditForm />} top={PROFILE_EDIT_FORM_TOP} left={PROFILE_EDIT_FORM_LEFT} transform={PROFILE_EDIT_FORM_TRANFORM} zIndex={PROFILE_EDIT_FORM_Z_INDEX} handleDimmedClick={() => setIsProfileEditModalOpen(false)} />
+        <Modal
+          component={<ProfileEditForm myProfile={myProfile!} />}
+          top={PROFILE_EDIT_FORM_TOP}
+          left={PROFILE_EDIT_FORM_LEFT}
+          transform={PROFILE_EDIT_FORM_TRANFORM}
+          zIndex={PROFILE_EDIT_FORM_Z_INDEX}
+          handleDimmedClick={() => setIsProfileEditModalOpen(false)}
+        />
       )}
     </>
   );
 };
 
-const ProfileEditForm = () => {
+const ProfileEditForm = ({ myProfile }: { myProfile: Friend }) => {
+  //api 연결
+  const [profileImg, setProfileImg] = useState<File | null>(null);
+  const [username, onUsernameChange, setUsername] = useInput(myProfile.username);
+
+  const handleProfileImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setProfileImg(e.target.files[0]);
+    }
+  };
+
+  const postProfileChange = () => {
+    const formData = new FormData();
+    formData.append('username', username);
+    if (profileImg) formData.append('profileImg', profileImg);
+    //axios
+  };
+
   return (
-    <S.ProfileEditForm>
-      <S.ProfileSection horizonPadding="2rem">
-        <S.Profile>
-          <S.ProfileImage padding="2rem" size="10rem" src="https://avatars.githubusercontent.com/u/55306894?s=80&u=aedb7854f1fd10d8eb6dc1272f1583dbb255f5b8&v=4" />
-          <S.ProfileInfo height="3.5rem" marginTop="-2rem">
-            <S.SizedText fontSize="1.5rem">
-              <S.Username>모작</S.Username>님
-              <S.PencilIcon />
-            </S.SizedText>
-            <S.UserId>@mojac</S.UserId>
-          </S.ProfileInfo>
-        </S.Profile>
-      </S.ProfileSection>
-      <S.ProfileMessageSection>안녕하세요</S.ProfileMessageSection>
-      <S.ProfileEditApplyButton>적용</S.ProfileEditApplyButton>
+    <S.ProfileEditForm onSubmit={postProfileChange}>
+      <S.Profile>
+        <S.ProfileImageForm>
+          <img src={profileImg ? URL.createObjectURL(profileImg) : `${HOST}/${myProfile.profileImg}`} alt="profile-img" />
+          <S.EditRound>
+            <input type="file" onChange={handleProfileImageChange} />
+            <S.EditIcon />
+          </S.EditRound>
+        </S.ProfileImageForm>
+        <S.ProfileInfo height="3.5rem" marginTop="-2rem">
+          <S.SizedText fontSize="14px">
+            <S.InputBar placeholder="NICKNAME" value={username} onChange={onUsernameChange} /> 님
+          </S.SizedText>
+          <S.UserId>@{myProfile.userId}</S.UserId>
+        </S.ProfileInfo>
+      </S.Profile>
+      <S.ProfileEditApplyButton isDone={true}>PROFILE CHANGE</S.ProfileEditApplyButton>
     </S.ProfileEditForm>
   );
 };


### PR DESCRIPTION
## 요약
- 프로필 수정 API 연결

## 작동 화면
![Dec-08-2022 23-41-17](https://user-images.githubusercontent.com/73420533/206475508-c42221eb-3e47-499b-96ca-5903b2aa4b68.gif)
- 기본 로직은 회원가입 창과 똑같습니다. 

## 관련 Task
4-2

## 비고
- 기본 로직은 회원가입을 참고했습니다 API단도 회원가입을 참고해주시면 좋을 것 같습니다.
- axios로 해도되는데 뭔가 안될까봐 회원가입에서 사용한 fetch 방법을 그대로 사용했습니다 ( 회원가입은 POST고 여기는 PATCH인데 동일하게 사용 가능하겠죠..? ) 
- 업로드 API가 완성이 안돼서 연결 코드만 작성해놓았습니다
- null 일 때는 사진 제거로 하기로 했는데 지금 기본 이미지로 돌아가는 버튼이 없어서 ( 파일 선택 버튼 -> 취소 시 그냥 이전 사진이 그대로 남아있음 ) null로 들어갈 일은 아마 없을 것 같습니다.
- 파일은 FormData 형식으로 보내야되는데 undefined는 FormData에 붙일 수가 없어서 사진을 변경하지 않을 시에는 아예 profileImg 칼럼이 없는 상태로 들어갑니다