### PR TITLE
[FE] [86] 테스크 모달의 공개 여부를 변경할 수 없는 문제

### DIFF
--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -168,7 +168,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask 
             />
             <input type="number" {...register('importance')} hidden={true} />
             <Row title="중요도" content={<ImportanceInput importance={importance} handleStarClick={handleStarClick} />} />
-            <Row title="공개" content={<input type="checkbox" defaultChecked={currentTask ? currentTask.isPublic : true} {...register('isPublic')} />} />
+            <Row title="공개" content={<input type="checkbox" {...register('isPublic')} />} />
           </tbody>
         </S.FormTable>
         <S.DetailButton onClick={() => setIsDetailOpen(!isDetailOpen)}>


### PR DESCRIPTION
## 요약
- 테스크 수정 모달을 구현하면서 테스크 생성 시 값이 True로 고정되고 / 수정 시 기존의 isPublic 값으로 고정되는 문제가 있었습니다.
- defaultChecked 사용 시 값을 보내기 직전에 isPublic 값이 defaultChecked로 다시 바뀌는 것 같습니다.
- 간단하게 해결할 수 없어서 일단 생성, 수정 시 모두 defaultChecked가 설정되어 있지 않는 걸로 임시 수정했습니다. ( -> 모달이 열릴 때 isPublic이 체크되어 있지 않는 상태로 시작합니다 )

## 관련 Task
86

## 비고
