### PR TITLE
[FE] [5-10] 친구의 LOG / MAP 탭 캘린더 연결

### DIFF
--- a/client/src/components/MainContainer/Calendar.tsx
+++ b/client/src/components/MainContainer/Calendar.tsx
@@ -4,7 +4,7 @@ import { EngMonth, Days, WEEK_LENGTH, HOST } from '../../constants';
 import MenuSelector from './MenuSelector';
 import * as S from './Calendar.style';
 import { useRecoilState } from 'recoil';
-import { menuState } from '../common/atoms';
+import { menuState, visitState } from '../common/atoms';
 import axios from 'axios';
 
 interface DateContainerProps {
@@ -23,6 +23,7 @@ const Calendar = () => {
   const { currentDate, getFirstDay, getLastDate } = useCurrentDate();
   const [calendarDate, setCalendarDate] = useState(currentDate);
   const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
 
   //Vars
   const firstDay = getFirstDay(calendarDate);
@@ -52,7 +53,9 @@ const Calendar = () => {
     const getEmoticon = async () => {
       try {
         if (currentMenu == 'LOG' || currentMenu == 'MAP' || currentMenu == 'DIARY') {
-          const result = await axios.get(`${HOST}/api/v1/calendar/task?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
+          const result = currentVisit.isMe
+            ? await axios.get(`${HOST}/api/v1/calendar/task?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`)
+            : await axios.get(`${HOST}/api/v1/calendar/task/${currentVisit.userId}?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
           setCalendarPercent(result.data);
         } else if (currentMenu == 'GOAL') {
           const result = await axios.get(`${HOST}/api/v1/calendar/goal?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
@@ -63,7 +66,7 @@ const Calendar = () => {
       }
     };
     getEmoticon();
-  }, [calendarDate.getMonth(), currentMenu]);
+  }, [calendarDate.getMonth(), currentMenu, currentVisit]);
 
   return (
     <>


### PR DESCRIPTION
## 요약
- 친구의 LOG / MAP 탭 캘린더 연결

## 작동 화면
![Dec-09-2022 00-27-23](https://user-images.githubusercontent.com/73420533/206486516-3acdcb9d-a7bb-43da-8a89-92eee5c697d4.gif)
- 친구에 따라 LOG / MAP 탭의 상태가 테스크 존재 여부로 표시됩니다.


## 관련 Task
5-10

## 비고
- 목표 탭은 아직 API 완성이 안돼서 연결이 안됐습니다.
- private 테스크도 존재 여부에 포함되는 문제가 있습니다. 87번 백로그로 등록했습니다.