### PR TITLE
[BE] [87] 친구의 일별 태스크 존재 여부 조회 API 수정

### DIFF
--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -99,7 +99,7 @@ router.get('/task/:user_id', authenticateToken, async (req: AuthorizedRequest, r
     const isNotFriend = ((await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket).length === 0;
     if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 태스크를 조회할 수 없어요.' });
 
-    const datesTaskExists = (await executeSql('select date_format(date, "%d") as date, count(idx) from task where user_idx = ? and date like ? group by date', [friendIdx, dateSearchFormat])) as RowDataPacket;
+    const datesTaskExists = (await executeSql('select date_format(date, "%d") as date, count(idx) from task where public = true and user_idx = ? and date like ? group by date', [friendIdx, dateSearchFormat])) as RowDataPacket;
     datesTaskExists.forEach(({ date }) => {
       result[parseInt(date) - 1] = true;
     });


### PR DESCRIPTION
## 요약
친구의 일별 태스크 존재 여부 조회 시 친구의 비공개 태스크가 포함되어 캘린더에는 존재하는 것으로 표시되지만 해당 날짜 조회 시 태스크가 조회되지 않는 문제가 있었습니다.
태스크 존재 여부 결정 시 공개 태스크만을 고려하도록 SQL을 수정하여 해결하였습니다.
기타 변경 사항은 없으며 응답 및 요청 등에 대한 정보는 아래 PR과 동일합니다.
- https://github.com/boostcampwm-2022/web19-Boostart/pull/190

## 작동 화면
- 왼쪽 화면 : `pikachu`
- 오른쪽 화면 : `pikachu`와 친구 관계인 `sy`
1. 오른쪽 화면 : `/friend`를 통해 `pikachu`와 친구 관계임을 확인
2. 왼쪽 화면 : `pikachu`에게 `2022-12-09`에 비공개 일정만 존재하는 것을 확인
3. 오른쪽 화면 : `/calendar/task/pikachu?year=2022&month=12`를 통해 `2022-12-09`의 태스크 존재 여부가 `false`인 것을 확인

[5237802d-cf3d-44f5-8db8-0b8e44b84266.webm](https://user-images.githubusercontent.com/92143119/206507071-e639cb1f-2c4d-4b35-a276-d776c4131cfd.webm)

## 작업 내용
1. 친구의 태스크 존재 여부 조회 시 공개 태스크만 포함되도록 수정

## 테스트 방법
1. 로그인을 완료합니다.
4. 주소창에 `http://localhost:8000/api/v1/calendar/task/${user_id}?year=${year}&month=${month}`를 입력합니다.

## 관련 Task
- [87]