### PR TITLE
[BE] [4-33] 친구의 일별 평균 목표 달성률 조회 API 구현

### DIFF
--- a/server/src/api/calendar.ts
+++ b/server/src/api/calendar.ts
@@ -143,4 +143,47 @@ router.get('/goal', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
+router.get('/goal/:user_id', authenticateToken, async (req: AuthorizedRequest, res) => {
+  const { userIdx } = req.user;
+  const { user_id: friendId } = req.params;
+
+  try {
+    Object.values(CalendarQueryKeys).forEach((key) => validate(key, req.query[key] as string));
+  } catch (error) {
+    return res.status(400).send({ msg: error.message });
+  }
+
+  const year = parseInt(req.query.year as string);
+  const month = parseInt(req.query.month as string);
+
+  const dateSearchFormat = `${year}-${month}-%`;
+  const lastDate = new Date(year, month, 0);
+  const lastDay = lastDate.getDate();
+
+  const result = Array.from({ length: lastDay }, () => 0);
+  try {
+    const friend = (await executeSql('select idx from user where user_id = ?', [friendId])) as RowDataPacket;
+    if (friend.length === 0) return res.status(404).send({ msg: '존재하지 않는 사용자예요.' });
+
+    const { idx: friendIdx } = friend[0];
+    if (userIdx === friendIdx) return res.redirect(`/api/${API_VERSION}/calendar/task?year=${year}&month=${month}`);
+
+    const isNotFriend = ((await executeSql('select * from friendship where (sender_idx = ? and receiver_idx = ?) or (sender_idx = ? and receiver_idx = ?)', [userIdx, friendIdx, friendIdx, userIdx])) as RowDataPacket).length === 0;
+    if (isNotFriend) return res.status(403).send({ msg: '친구가 아닌 사용자의 태스크를 조회할 수 없어요.' });
+
+    const taskLabelSql = 'select date, label_idx, amount from task_label inner join task on task_label.task_idx = task.idx where done = true and user_idx = ? and date like ?';
+    const currentAmountSql = 'cast(ifnull(sum(task_label.amount), 0) as unsigned)';
+    const dailyRateSql = `select goal.date, case when over then if(${currentAmountSql} / goal.amount > 1, 1, ${currentAmountSql} / goal.amount) when ${currentAmountSql} > goal.amount then 0 else 1 end as rate from goal left join (${taskLabelSql}) task_label on goal.label_idx = task_label.label_idx and goal.date = task_label.date where user_idx = ? and goal.date like ? group by idx, date`;
+
+    const dailyAverageRate = (await executeSql(`select date_format(date, "%d") as date, avg(rate) as averageRate from (${dailyRateSql}) daily_rate group by date`, [friendIdx, dateSearchFormat, friendIdx, dateSearchFormat])) as RowDataPacket;
+    dailyAverageRate.forEach(({ date, averageRate }) => {
+      result[parseInt(date) - 1] = parseFloat(averageRate);
+    });
+
+    res.json(result);
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## 요약
월 단위로 일별 평균 목표 달성률을 조회할 수 있는 API를 구현하였습니다.

목표 달성률은 아래의 조건에 따라 계산하였습니다.
- 목표 달성률 범위 : 0 이상 1 이하
- 목표가 존재하지 않는 경우 : `0`
- 목표의 `over = true`인 경우 (설정한 값 이상의 목표를 달성해야 하는 경우)
   - `현재 값 / 목표 값`
   - 목표 값보다 높은 값을 달성한 경우 : `1`
- 목표의 `over = false`인 경우 (설정한 값을 넘지 않아야 하는 목표의 경우)
   - 설정한 값을 넘지 않은 경우 : `1`
   - 설정한 값을 넘은 경우 : `0`

친구의 목표 달성률은 아래의 이유로 비공개 태스크의 라벨 정보도 포함하여 계산하였습니다.
1. 목표는 공개 여부를 설정할 수 없으므로 항상 공개인 상태
2. 비공개 태스크의 라벨 정보를 목표에 포함하지 않을 경우 목표 달성률 측정이 애매해지고 친구의 목표 달성률 정보는 부정확한 정보가 됨

해당 API의 요청 및 응답 정보입니다.

- 요청 URL : `/calendar/goal/:usre_id?year=${year}&month=${month}`
   - `user_id` : 조회하고 싶은 친구의 아이디
   - `year` : 조회하고 싶은 연도
   - `month` : 조회하고 싶은 달
   - method : `GET`
- 응답
   - `float[]` (평균 목표 달성률 배열)
      - 배열의 크기는 요청한 달의 일수입니다.
      - `배열의 0번 index = 1일의 정보`, ... , `배열의 30번 index = 31일의 정보`
   - 본인에 대한 요청 : `/calendar/goal?year=${year}&month=${month}`로 `redirect` 처리
   - 연도 및 달 미지정, 잘못된 달 입력 : `400`
   - 친구가 아닌 사용자에 대한 요청 : `403`
   - 존재하지 않는 사용자에 대한 요청 : `404`
   - DB 및 서버에 문제 발생 : `500`

## 작동 화면
1. `/friend`를 통해 친구 목록 확인
2. 존재하지 않는 `ssssss` 사용자에 대한 조회 요청
3. `404` 코드와 함께 존재하지 않는 사용자라는 메시지가 반환되는 것을 확인
4. 친구가 아닌 `j0702` 사용자에 대한 조회 요청
5. `403` 코드와 함께 친구가 아닌 사용자의 정보를 조회할 수 없다는 메시지가 반환되는 것을 확인
6. 친구인 `sy` 사용자에 대한 조회 요청
7. 일별 평균 목표 달성률 배열이 반환되는 것을 확인

[395c7aba-f90e-4f2a-8bf1-c2adcd296cb2.webm](https://user-images.githubusercontent.com/92143119/206766573-93751b14-b43c-4e50-a506-a2e7fc2c379e.webm)

## 작업 내용
1. 친구의 일별 평균 목표 달성률 조회 API 구현

## 테스트 방법
1. 로그인을 완료합니다.
8. 주소창에 `http://localhost:8000/api/v1/calendar/goal/${user_id}?year=${year}&month=${month}`를 입력합니다.

## 관련 Task
- [4-33]