### PR TITLE
[FE] [91] 캘린더 로고의 크기가 커 퍼센트가 높거나 낮은 값은 올바르게 표시되지 않는 오류

### DIFF
--- a/client/src/components/MainContainer/Calendar.style.ts
+++ b/client/src/components/MainContainer/Calendar.style.ts
@@ -120,9 +120,17 @@ export const Date = styled.span`
   pointer-events: none;
 `;
 
+export const LogoWrapper = styled.div`
+  height: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const DateLogo = styled.span<{
   percentage: number;
 }>`
+  line-height: 1.5rem;
   font-size: 2rem;
   font-family: 'Baumans', cursive;
   background: linear-gradient(to top, #99b1db ${(props) => props.percentage}%, #ddd 0%);

--- a/client/src/components/MainContainer/Calendar.tsx
+++ b/client/src/components/MainContainer/Calendar.tsx
@@ -111,7 +111,9 @@ const DateContainer = ({ calendarYear, calendarMonth, calendarDate, percent }: D
     <>
       <S.DateBox onClick={selectCurrentDate}>
         <S.TodayMarker isToday={isToday}>
-          <S.DateLogo percentage={percent * 100}>B</S.DateLogo>
+          <S.LogoWrapper>
+            <S.DateLogo percentage={percent * 100}>B</S.DateLogo>
+          </S.LogoWrapper>
         </S.TodayMarker>
         <S.Date>{calendarDate}</S.Date>
       </S.DateBox>


### PR DESCRIPTION
## 요약
- 캘린더 로고의 크기를 조정했습니다.

## 작동 화면
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/73420533/206835966-7a667604-f5cc-4ee1-96f5-3b3bc8c2ca08.png">
- 91% 등 과 같이 세밀한 값도 눈으로 확인할 수 있습니다.

## 작업 내용
로고의 크기가 글자 모양을 넘게 설정되어 있어, 90퍼 정도가 넘으면 색이 꽉차 보이는 오류가 있었습니다. 이를 조정했습니다.

## 관련 Task
91
