### PR TITLE
[FE] [92] 불필요한 소켓 연결 해제

### DIFF
--- a/client/src/components/common/Socket.ts
+++ b/client/src/components/common/Socket.ts
@@ -33,6 +33,7 @@ class GlobalSocket {
   }
 
   initialize() {
+    this._instance.disconnect();
     this._instance = io(HOST!);
   }
 }


### PR DESCRIPTION
## 요약
- 소켓 재연결 시 기존 연결을 끊도록 개선했습니다.
## 비고
### 개선 전 console.log (서버)
```
-- 서버와 연결되어 있는 소켓 목록 --
[Map Iterator] {
  '91SprlxW0ybLji8VAAAD',
  '5g7Tr0OiVxrf5bZ_AAAF',
  '6zyeODOKaJvU2QeMAAAH',
  'f-6SMSUXIPm7W0SdAAAJ'
}
-- 접속중인 유저의 소켓 아이디 목록 --
{ '32': 'f-6SMSUXIPm7W0SdAAAJ' }
```
### 개선 후 console.log
```
-- 서버와 연결되어 있는 소켓 목록 --
[Map Iterator] { 'AIu6tUmHPuPRQJ3wAAAf' }
-- 접속중인 유저의 소켓 아이디 목록 --
{ '8': 'AIu6tUmHPuPRQJ3wAAAf' }
```