### PR TITLE
[FE] [9-3] map 탭에서 친구의 task 동시 확인 가능

### DIFF
--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -65,4 +65,10 @@ export const FRIEND_REQUEST_ACTION = {
   REJECT: axios.delete,
 };
 
-export const API_VERSION = 'api/v1'
+export const API_VERSION = 'api/v1';
+
+export const TaskTargetType = {
+  me: 'me',
+  friend: 'friend',
+  both: 'both',
+};

--- a/server/app.ts
+++ b/server/app.ts
@@ -72,12 +72,9 @@ io.engine.on('headers', async (_, request) => {
   const tokenCookie = cookies.find((cookie) => cookie.substring(0, 6) === 'token=');
   const token = tokenCookie.substring(6);
 
-  jwt.verify(token, TOKEN_SECRET, (error, { userIdx }) => {
-    if (error) {
-      console.log(error);
-      return;
-    }
-    connectionIdToUserIdx[connectionId] = userIdx;
+  jwt.verify(token, TOKEN_SECRET, (error, user) => {
+    if (error || !user) return;
+    connectionIdToUserIdx[connectionId] = user.userIdx;
   });
 });
 


### PR DESCRIPTION
## 요약
 map 탭에서 친구의 task를 동시에 확인할 수 있습니다
## 작동 화면
![map 시연](https://user-images.githubusercontent.com/109147404/206844427-70f9f839-94c6-486a-9674-d6da7edadb96.gif)

없다면 생략

## 작업 내용
- task 위치 마커
 1. 기본적으로 본인의 task 위치를 조회합니다 
 2. 방문중인 페이지가 나의 페이지가 아니라면 선택된 친구의 task 위치를 함께 조회합니다
 3. 친구의 task는 노란색으로, 나의 task는 보라색으로 마커를 표시합니다.
-task list
 1. 좌측에는 본인의 task list가, 우측에는 친구의 task list가 표시됩니다.
 2. 위치정보를 가진 task가 해당일자에 존재하지 않는다면 list도 표시되지 않습니다.
 3. 나와 친구 둘다 위치정보를 가진 task가 없다면 중앙에 '위치정보를 가진 일정을 추가해주세요' 라는 문구를 나타냅니다
- map 영역 설정
 1. 초기에는 조회된 모든 task를 확인 가능한 크기로 지도 영역을 설정합니다.
 2. 좌측 목록 아래 전체보기를 클릭시 나의 일정 전체를 확인가능한 영역으로 설정합니다.
 3. 우측목록 아래 전체보기를 클릭시 친구의 일정 전체를 확인가능한 영역으로 설정합니다.
 4. 나와 친구 둘다 task가 있을 경우 중앙 상단에 두 사람 모두의 task를 포함하는 영역으로 전환하는 전체보기 버튼이 생성됩니다.


## 관련 Task
-[9-3]

## 비고
