### PR TITLE
[BE] [59] 프로필 수정 API 수정

### DIFF
--- a/server/src/api/user.ts
+++ b/server/src/api/user.ts
@@ -1,11 +1,19 @@
 import { Router } from 'express';
 import { RowDataPacket } from 'mysql2';
 import { executeSql } from '../db';
-import { AuthorizedRequest } from '../types';
+import { AuthorizedRequest, UpdateProfileRequest } from '../types';
 import { authenticateToken } from '../utils/auth';
 import { DEFAULT_PROFILE } from '../constants';
+import fileUpload from 'express-fileupload';
+import fs from 'fs';
 
 const router = Router();
+
+router.use(
+  fileUpload({
+    createParentPath: true,
+  })
+);
 
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
@@ -28,13 +36,32 @@ router.get('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
   }
 });
 
-router.patch('/me', authenticateToken, async (req: AuthorizedRequest, res) => {
+router.patch('/me', authenticateToken, async (req: UpdateProfileRequest, res) => {
   const { userIdx } = req.user;
-  let { username, profileImg } = req.body;
-  if (!username || profileImg === undefined) return res.status(400).json({ msg: '올바른 정보를 입력해주세요.' });
-  if (!profileImg) profileImg = DEFAULT_PROFILE;
+  const { username } = req.body;
+
+  if (!username) return res.status(400).json({ msg: '올바른 정보를 입력해주세요.' });
+
+  let updateSql = 'update user set username = ?';
+  const updateValue = [username];
+
+  if (req.files) {
+    const { profile_img: currentProfileImg } = ((await executeSql('select profile_img from user where idx = ?', [userIdx])) as RowDataPacket)[0];
+    if (currentProfileImg !== DEFAULT_PROFILE && fs.existsSync(`./uploads/${currentProfileImg}`)) fs.rmSync(`./uploads/${currentProfileImg}`);
+
+    const { profileImg } = req.files;
+    const profileImgFilename = profileImg.name; // TODO: 해시하기
+    profileImg.mv('./uploads/' + profileImgFilename);
+
+    updateSql += ', profile_img = ?';
+    updateValue.push(profileImgFilename);
+  }
+
+  updateSql += ' where idx = ?';
+  updateValue.push(userIdx);
+
   try {
-    await executeSql('update user set username = ?, profile_img = ? where idx = ?', [username, profileImg, userIdx]);
+    await executeSql(updateSql, updateValue);
     res.sendStatus(200);
   } catch {
     res.sendStatus(500);

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -24,6 +24,8 @@ declare interface SignupRequest extends Request {
   };
 }
 
+declare interface UpdateProfileRequest extends AuthorizedRequest, SignupRequest {}
+
 declare interface PutEmoticonRequest extends AuthorizedRequest {
   emoticon?: number;
 }


### PR DESCRIPTION
## 요약
프로필 수정 시 새로 지정한 프로필 이미지를 저장하지 않는 버그를 수정하였습니다.
프로필 수정 모달에서 보내는 요청의 형태는 다음과 같습니다.
- 프로필 이미지를 변경하지 않았을 경우
   - `req.body = { username }`
   - `req.files = null`
- 프로필 이미지를 변경하였을 경우
   - `req.body = { username }`
   - `req.files = ${설정한 파일의 정보}`

따라서 `req.files`의 존재 여부에 따라 프로필 이미지 변경 여부를 결정하였습니다.
기존 프로필 이미지를 삭제하고 기본 프로필 이미지 설정을 원하는 경우에 대해서는 추가적인 컬럼 설정 등의 협의가 필요할 것 같습니다.
추가로 프로필 이미지를 변경한 경우 기존 프로필 이미지 파일은 삭제하도록 구현하였습니다.

기타 변경 사항은 없으며 요청 및 응답에 대한 내용은 아래 PR과 동일합니다.
- https://github.com/boostcampwm-2022/web19-Boostart/pull/132

## 작동 화면
1. 로그인을 완료한 뒤 우측의 햄버거 버튼을 클릭합니다.
2. 우측 상단의 프로필 수정 버튼을 클릭합니다.
3. 변경할 프로필 이미지를 설정합니다.
4. `PROFILE CHANGE` 버튼을 클릭한 뒤 새로고침하여 변경된 프로필을 확인합니다.

[ce8f7ca0-bcae-46b5-b30e-0e98fb564b16.webm](https://user-images.githubusercontent.com/92143119/206887432-4558a0a5-5657-4c73-8e6a-579a4bcf733c.webm)

## 작업 내용
1. 프로필 이미지 변경 시 프로필 이미지 업로드 구현
2. 프로필 이미지 변경 시 기존 프로필 이미지 삭제

## 테스트 방법
1. 로그인을 완료합니다.
2. 메인 화면 우측의 햄버거 버튼을 클릭합니다.
3. 우측 상단의 프로필 수정 버튼을 클릭합니다.
4. 변경할 프로필 이미지를 설정합니다.
5. `PROFILE CHANGE` 버튼을 클릭한 뒤 새로고침하여 변경된 프로필을 확인합니다.

## 관련 Task
- [59]