### PR TITLE
[FE] [105] 토큰 만료 시 새로고침

### DIFF
--- a/client/src/components/common/utils.ts
+++ b/client/src/components/common/utils.ts
@@ -1,0 +1,15 @@
+import axios, { AxiosError } from 'axios';
+
+export const authorizedHttpRequest = async (callback: Function) => {
+  try {
+    return await callback();
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const response = (error as AxiosError).response;
+      if (response && (response.status === 401 || response.status === 403)) {
+        window.location.reload();
+      }
+    }
+    throw error;
+  }
+};

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -4,7 +4,7 @@ import { AuthorizedRequest } from '../types/index';
 import { Response, NextFunction } from 'express';
 
 export const generateAccessToken = (data: object) => {
-  return jwt.sign(data, TOKEN_SECRET, { expiresIn: '180s' });
+  return jwt.sign(data, TOKEN_SECRET, { expiresIn: '1800s' });
 };
 
 export const authenticateToken = (req: AuthorizedRequest, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## 요약
- 클라이언트가 API 응답으로 401이나 403을 받을 경우 새로고침이 일어나며, 훅에 의해 로그인 페이지로 리다이렉트됩니다.

## 작업 내용
1. 로그인이 필요한 요청을 감싸 인증 실패 에러를 처리하는 함수를 작성했습니다.
2. 토큰 만료 시 새로고침이 적용되도록 수정했습니다.

## 비고
- 목표 탭에만 적용