### PR TITLE
[FE] [85] task / goal 생성 시 캘린더에 바로 반영

### DIFF
--- a/client/src/components/MainContainer/Calendar.tsx
+++ b/client/src/components/MainContainer/Calendar.tsx
@@ -4,7 +4,7 @@ import { EngMonth, Days, WEEK_LENGTH, HOST } from '../../constants';
 import MenuSelector from './MenuSelector';
 import * as S from './Calendar.style';
 import { useRecoilState } from 'recoil';
-import { menuState, visitState } from '../common/atoms';
+import { menuState, visitState, calendarState } from '../common/atoms';
 import axios from 'axios';
 
 interface DateContainerProps {
@@ -24,6 +24,7 @@ const Calendar = () => {
   const [calendarDate, setCalendarDate] = useState(currentDate);
   const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
   const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+  const [currentCalendar, setCurrentCalendar] = useRecoilState(calendarState);
 
   //Vars
   const firstDay = getFirstDay(calendarDate);
@@ -47,8 +48,6 @@ const Calendar = () => {
     setCalendarDate(new Date(currentDate));
   }, [currentDate]);
 
-  const [calendarPercent, setCalendarPercent] = useState([]);
-
   useEffect(() => {
     const getCalendarData = async () => {
       try {
@@ -56,12 +55,12 @@ const Calendar = () => {
           const result = currentVisit.isMe
             ? await axios.get(`${HOST}/api/v1/calendar/task?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`)
             : await axios.get(`${HOST}/api/v1/calendar/task/${currentVisit.userId}?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
-          setCalendarPercent(result.data);
+          setCurrentCalendar(result.data);
         } else if (currentMenu == 'GOAL') {
           const result = currentVisit.isMe
             ? await axios.get(`${HOST}/api/v1/calendar/goal?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`)
             : await axios.get(`${HOST}/api/v1/calendar/goal/${currentVisit.userId}?year=${calendarDate.getFullYear()}&month=${calendarDate.getMonth() + 1}`);
-          setCalendarPercent(result.data);
+          setCurrentCalendar(result.data);
         }
       } catch (error) {
         console.log(error);
@@ -70,6 +69,9 @@ const Calendar = () => {
     getCalendarData();
   }, [calendarDate.getMonth(), currentMenu, currentVisit]);
 
+  useEffect(() => {
+    console.log(currentCalendar);
+  }, [currentCalendar]);
   return (
     <>
       <S.CalendarTitle>CAL</S.CalendarTitle>
@@ -94,7 +96,7 @@ const Calendar = () => {
             return <div key={'emptyBox' + idx}></div>;
           })}
           {monthDays.map((_, idx) => {
-            return <DateContainer key={'date' + (idx + 1)} calendarYear={calendarDate.getFullYear()} calendarDate={idx + 1} calendarMonth={calendarDate.getMonth()} percent={calendarPercent[idx]}></DateContainer>;
+            return <DateContainer key={'date' + (idx + 1)} calendarYear={calendarDate.getFullYear()} calendarDate={idx + 1} calendarMonth={calendarDate.getMonth()} percent={currentCalendar[idx]}></DateContainer>;
           })}
         </S.DateSelector>
         <MenuSelector />

--- a/client/src/components/TaskModal/TaskModal.tsx
+++ b/client/src/components/TaskModal/TaskModal.tsx
@@ -11,6 +11,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import axios from 'axios';
 import { HOST } from '../../constants';
+import { useRecoilState } from 'recoil';
+import { calendarState } from '../common/atoms';
 
 interface Props {
   handleCloseButtonClick: () => void;
@@ -42,6 +44,8 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask 
   const { currentDate, getMonth, getDate } = useCurrentDate();
 
   const [importance, setImportance] = useState(currentTask ? currentTask.importance : DEFAULT_IMPORTANCE);
+
+  const [currentCalendar, setCurrentCalendar] = useRecoilState(calendarState);
 
   const contents = {
     close: '닫기 ▲',
@@ -100,6 +104,7 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask 
   const createTask = async (body: FieldValues) => {
     await httpPostTask({ ...body, date: formatDate(currentDate) });
     handleCloseButtonClick();
+    await httpGetCalendar();
   };
 
   const editTask = async (body: FieldValues) => {
@@ -109,6 +114,11 @@ const TaskModal = ({ handleCloseButtonClick, tagList, fetchTagList, currentTask 
 
   const httpPostTask = async (body: FieldValues) => {
     await axios.post(`${HOST}/api/v1/task`, body);
+  };
+
+  const httpGetCalendar = async () => {
+    const result = await axios.get(`${HOST}/api/v1/calendar/task?year=${currentDate.getFullYear()}&month=${currentDate.getMonth() + 1}`);
+    setCurrentCalendar(result.data);
   };
 
   const httpPatchTask = async (body: FieldValues) => {

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -12,3 +12,7 @@ export const menuState = atom({
   key: 'currentMenu',
   default: '',
 });
+export const calendarState = atom({
+  key: 'currentCalendar',
+  default: [],
+});


### PR DESCRIPTION
## 요약
- task / goal 생성 시 캘린더에 바로 반영

## 작동 화면
![Dec-12-2022 15-40-35](https://user-images.githubusercontent.com/73420533/206979165-b6972b6c-9a3f-4404-9761-4b93e4f14c40.gif)
- task 생성 시 바로 반영

![Dec-12-2022 15-39-30](https://user-images.githubusercontent.com/73420533/206979177-4efd5ea9-6550-49b7-aad1-8098de0deddc.gif)
- goal 생성 시 바로 반영

## 작업 내용
- 캘린더 배열을 calendarState 로 전역화 했습니다.

## 관련 Task
85

