### PR TITLE
[FE] [108] 디자인 조정 / 컴포넌트 공통화

### DIFF
--- a/client/src/components/FriendsBar/FriendsBar.style.ts
+++ b/client/src/components/FriendsBar/FriendsBar.style.ts
@@ -12,6 +12,7 @@ export const FriendsBarContainer = styled.div`
   align-items: center;
   transform: translateY(-0.35rem);
   box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
+  z-index: 500;
 `;
 
 export const ProfileBox = styled.div<{

--- a/client/src/components/MainContainer/Calendar.style.ts
+++ b/client/src/components/MainContainer/Calendar.style.ts
@@ -8,7 +8,7 @@ export const CalendarTitle = styled.span`
   font-size: 1.7rem;
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
-  z-index: -1;
+  z-index: 1;
 `;
 export const CalendarContainer = styled.div`
   width: 100%;

--- a/client/src/components/MainContainer/DateSelector.tsx
+++ b/client/src/components/MainContainer/DateSelector.tsx
@@ -7,9 +7,9 @@ interface DateSelectArrowProps {
 }
 
 export const DateController = styled.span`
-  width: 14rem;
+  width: 200px;
   color: var(--color-main);
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   font-family: 'Press Start 2P', cursive;
   display: flex;
   justify-content: space-between;

--- a/client/src/components/MainContainer/Diary.style.ts
+++ b/client/src/components/MainContainer/Diary.style.ts
@@ -1,27 +1,5 @@
 import styled from 'styled-components';
 
-export const DiaryTitle = styled.span`
-  display: inline-block;
-  color: white;
-  font-size: 1.7rem;
-  font-family: 'Press Start 2P', cursive;
-  transform: translate(1.75rem, 0.43rem);
-  z-index: 1;
-  span {
-    font-size: 1.2rem;
-  }
-`;
-
-export const Container = styled.div`
-  height: 36rem;
-  background: white;
-  border-radius: 1rem;
-  margin-top: 0rem;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
-`;
-
 export const DiaryContainer = styled.div`
   position: relative;
   user-select: none;
@@ -43,12 +21,5 @@ export const DiaryNavBarSection = styled.div`
   align-items: flex-end;
   grid-area: nav;
   box-sizing: border-box;
-  cursor: default;
-`;
-
-export const DateController = styled.span`
-  color: #99b1db;
-  font-size: 1.5rem;
-  font-family: 'Press Start 2P', cursive;
   cursor: default;
 `;

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,32 +1,21 @@
 import { useEffect } from 'react';
-import { useRecoilValue, useRecoilState } from 'recoil';
-import { visitState, menuState } from '../common/atoms';
+import { useRecoilState } from 'recoil';
+import { menuState } from '../common/atoms';
 import Canvas from './Canvas';
 import * as S from './Diary.style';
-import DateSelector from './DateSelector';
 
 const Diary = () => {
-  const currentVisit = useRecoilValue(visitState);
   const [currentMenu, setCurrentMenu] = useRecoilState(menuState);
 
   useEffect(() => {
     setCurrentMenu('DIARY');
   }, []);
-  
+
   return (
-    <>
-      <S.DiaryTitle>
-        DIARY <span> {currentVisit.isMe || `~${currentVisit.userId}`}</span>
-      </S.DiaryTitle>
-      <S.Container>
-        <S.DiaryContainer>
-          <S.DiaryNavBarSection>
-            <DateSelector />
-          </S.DiaryNavBarSection>
-          <Canvas />
-        </S.DiaryContainer>
-      </S.Container>
-    </>
+    <S.DiaryContainer>
+      <S.DiaryNavBarSection></S.DiaryNavBarSection>
+      <Canvas />
+    </S.DiaryContainer>
   );
 };
 

--- a/client/src/components/MainContainer/GoalManager.style.ts
+++ b/client/src/components/MainContainer/GoalManager.style.ts
@@ -265,6 +265,11 @@ export const LabelModalLabelColorInput = styled.input`
   outline: none;
 `;
 
+export const Container = styled.div`
+  height: 32.5rem;
+  position: relative;
+`;
+
 export const LabelModalLabelCreateButton = styled.button`
   outline: none;
   border: none;

--- a/client/src/components/MainContainer/GoalManager.tsx
+++ b/client/src/components/MainContainer/GoalManager.tsx
@@ -118,7 +118,7 @@ const GoalManager = () => {
   }, []);
 
   return (
-    <>
+    <S.Container>
       <S.GoalHead>
         <span>목표</span> <span>제목</span> <span>현황</span> <span>달성률</span>
       </S.GoalHead>
@@ -142,7 +142,7 @@ const GoalManager = () => {
           }}
         />
       )}
-    </>
+    </S.Container>
   );
 };
 

--- a/client/src/components/MainContainer/Log.style.ts
+++ b/client/src/components/MainContainer/Log.style.ts
@@ -305,9 +305,18 @@ export const TaskMainInfos = styled.div`
   pointer-events: none;
 `;
 
+export const LogNavBarSectionItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 200px;
+`;
+
 export const CheckBoxContainer = styled.div`
   display: flex;
   align-items: center;
+  justify-content: right;
+  width: 200px;
 `;
 
 export const CheckBoxLabel = styled.label`

--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -203,12 +203,10 @@ const Log = () => {
             </S.TimeBar>
           </S.TimeBarSection>
           <S.LogNavBarSection>
-            <S.SortOptionSelect>
-              <option value="tag">태그순</option>
-              <option value="time">시간순</option>
-              <option value="importance">중요도순</option>
-            </S.SortOptionSelect>
-            <DateSelector />
+            <S.LogNavBarSectionItem></S.LogNavBarSectionItem>
+            <S.LogNavBarSectionItem>
+              <DateSelector />
+            </S.LogNavBarSectionItem>
             <S.CheckBoxContainer>
               <S.CheckBoxLabel htmlFor="complete">완료</S.CheckBoxLabel>
               <S.CheckBox type="checkbox" id="complete" defaultChecked={completionCheckBoxStatus.complete} onChange={(e) => handleCheckBoxChange(e, 'complete')} />

--- a/client/src/components/MainContainer/MainContainer.tsx
+++ b/client/src/components/MainContainer/MainContainer.tsx
@@ -17,9 +17,9 @@ const MainContents = () => {
         <S.RightSection>
           <Routes>
             <Route path="log/" element={<Log />} />
-            <Route path="diary/" element={<Diary />} />
+            <Route path="diary/" element={<SubContainer title="DIARY" element={<Diary />} />} />
             <Route path="goal" element={<SubContainer title="GOAL" element={<GoalManager />} />} />
-            <Route path="map/" element={<Map />} />
+            <Route path="map/" element={<SubContainer title="MAP" element={<Map />} />} />
           </Routes>
         </S.RightSection>
       </S.MainContentContainer>

--- a/client/src/components/MainContainer/Map.tsx
+++ b/client/src/components/MainContainer/Map.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import axios from 'axios';
-import DateSelector from './DateSelector';
 import { HOST, TaskTargetType } from '../../constants';
 import useCurrentDate from '../../hooks/useCurrentDate';
 import { visitState, menuState } from '../common/atoms';
@@ -135,23 +134,25 @@ export const Map = () => {
   };
 
   return (
-    <>
-      <MapTitle>MAP{!currentVisit.isMe && <span> width {currentVisit.userId}</span>}</MapTitle>
-      <MapContainer>
-        <DateSelector />
-        <KakaoContainer>
-          <div ref={mapRef} style={{ width: '41rem', height: '31rem' }}></div>
-          {myTaskList.length > 0 && <TaskList isMyList={true} />}
-          {friendTaskList.length > 0 && <TaskList isMyList={false} />}
-          {myTaskList.length === 0 && friendTaskList.length === 0 && <TaskAlertBox>위치정보가 있는 Task를 추가해주세요</TaskAlertBox>}
-          {friendTaskList.length > 0 && myTaskList.length > 0 && <BothFocusButton onClick={() => setMapBoundary(TaskTargetType.both)}>전체보기</BothFocusButton>}
-        </KakaoContainer>
-      </MapContainer>
-    </>
+    <KakaoContainer>
+      <MapRef ref={mapRef}></MapRef>
+      {myTaskList.length > 0 && <TaskList isMyList={true} />}
+      {friendTaskList.length > 0 && <TaskList isMyList={false} />}
+      {myTaskList.length === 0 && friendTaskList.length === 0 && <TaskAlertBox>위치정보가 있는 Task를 추가해주세요</TaskAlertBox>}
+      {friendTaskList.length > 0 && myTaskList.length > 0 && <BothFocusButton onClick={() => setMapBoundary(TaskTargetType.both)}>전체보기</BothFocusButton>}
+    </KakaoContainer>
   );
 };
 
 export default Map;
+
+const MapRef = styled.div`
+  width: 42.5rem;
+  height: 31rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-gray3);
+  padding: 0.5rem;
+`;
 
 const TaskListOnMap = styled.div<{
   isMyList: boolean;
@@ -190,31 +191,6 @@ const TaskItemOnMap = styled.div`
   flex-direction: column;
   justify-content: center;
   box-sizing: border-box;
-`;
-
-const MapTitle = styled.span`
-  display: inline-block;
-  color: white;
-  font-size: 1.7rem;
-  font-family: 'Press Start 2P', cursive;
-  transform: translate(1.75rem, 0.43rem);
-  z-index: 1;
-  span {
-    font-size: 1.2rem;
-  }
-`;
-const MapContainer = styled.div`
-  width: 100%;
-  height: 37rem;
-  position: relative;
-  background: white;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  align-items: center;
-  box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
-  user-select: none;
 `;
 
 const KakaoContainer = styled.div`

--- a/client/src/components/MainContainer/SubContainer.style.ts
+++ b/client/src/components/MainContainer/SubContainer.style.ts
@@ -1,14 +1,11 @@
 import styled from 'styled-components';
 
 export const Content = styled.div`
-  width: 100%;
+  width: 43.7rem;
   height: 36rem;
   background: white;
   border-radius: 1rem;
-  margin-top: 0rem;
-  margin-bottom: 1rem;
   padding: 0.5rem;
-  position: relative;
   box-shadow: 0px 0px 10px 5px rgba(175, 175, 175, 0.25);
   user-select: none;
 `;
@@ -20,6 +17,9 @@ export const Title = styled.span`
   font-family: 'Press Start 2P', cursive;
   transform: translate(1.75rem, 0.43rem);
   z-index: 1;
+  span {
+    font-size: 1.2rem;
+  }
 `;
 
 export const NavBarSection = styled.div`

--- a/client/src/components/MainContainer/SubContainer.tsx
+++ b/client/src/components/MainContainer/SubContainer.tsx
@@ -1,5 +1,7 @@
 import DateSelector from './DateSelector';
 import * as S from './SubContainer.style';
+import { useRecoilState } from 'recoil';
+import { visitState } from '../common/atoms';
 
 interface SubContainerProps {
   title: string;
@@ -7,9 +9,14 @@ interface SubContainerProps {
 }
 
 const SubContainer = ({ title, element }: SubContainerProps) => {
+  const [currentVisit, setCurrentVisit] = useRecoilState(visitState);
+
   return (
     <>
-      <S.Title>{title}</S.Title>
+      <S.Title>
+        {title}
+        <span> {currentVisit.isMe || `~${currentVisit.userId}`}</span>
+      </S.Title>
       <S.Content>
         <S.NavBarSection>
           <DateSelector />

--- a/client/src/components/TopBar/Clock/Clock.style.ts
+++ b/client/src/components/TopBar/Clock/Clock.style.ts
@@ -6,5 +6,5 @@ export const DigitalClock = styled.span`
   font-family: 'Baumans', cursive;
   align-self: flex-end;
   transform: translateY(0.3rem);
-  z-index: -1;
+  z-index: 500;
 `;

--- a/client/src/components/TopBar/TopBar.style.ts
+++ b/client/src/components/TopBar/TopBar.style.ts
@@ -18,7 +18,7 @@ export const MainTitle = styled.div`
   color: white;
   font-size: 5.5rem;
   font-family: 'Baumans', cursive;
-  z-index: -1;
+  z-index: 501;
 `;
 
 export const MenuIcon = styled.img`


### PR DESCRIPTION
## 작동 화면
<img width="1440" alt="스크린샷 2022-12-12 오후 8 20 02" src="https://user-images.githubusercontent.com/73420533/207035224-d73ff49b-7763-42db-9024-3a0fcdec5d83.png">

- 컴포넌트 타이틀이 컴포넌트보다 위에
- 컴포넌트 타이틀 / 시계 보다 친구 창의 모달이 더 위에
있도록 조정했습니다.
- LOG 탭의 DateSelector 위치를 중앙으로 조정했습니다.

![Dec-12-2022 20-37-08](https://user-images.githubusercontent.com/73420533/207035766-171c8c97-877c-4da0-a262-ea9ced897ab0.gif)
- DIARY / GOAL / MAP 모두 SubContainer로 공통화 했습니다.
  - 이제 해당 탭들의 타이틀과 날짜와 아이디가 모두 같은 위치에 동일하게 표시됩니다 :)@@!
- GOAL 추가와 TASK 추가 버튼이 최대한... 같은 위치에 보이도록 조정했습니다.
- 지도 탭의 디자인을 조정했습니다.

## 관련 Task
108
