### PR TITLE
[FE] [117] Friend 관련 API 분리 및 type정리

### DIFF
--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { PROFILE_EDIT_FORM_Z_INDEX, PROFILE_EDIT_FORM_TOP, PROFILE_EDIT_FORM_LEFT, PROFILE_EDIT_FORM_TRANFORM } from './Drawer.style';
 import { FRIEND_REQUEST_ACTION, HOST } from '../../constants';
+import { sendLogoutRequest } from '../FriendsBar/FriendsBarAPI';
 import Modal from '../common/Modal';
-import { Friend } from 'GlobalType';
 import * as S from './Drawer.style';
 import useInput from '../../hooks/useInput';
 import { myInfo } from '../common/atoms';
@@ -13,7 +13,6 @@ interface DrawerProps {
   isOpen: boolean;
   friendRequests: Friend[] | null;
   handleFriendRequests: Function;
-  handleLogoutButtonClick: React.MouseEventHandler;
 }
 interface ReceivedFriendRequestSectionProps {
   friendRequests: Friend[] | null;
@@ -30,7 +29,7 @@ interface ProfileSectionProps {
   handleProfileEditButtonClick: React.MouseEventHandler;
 }
 
-const Drawer = ({ isOpen, friendRequests, handleFriendRequests, handleLogoutButtonClick }: DrawerProps) => {
+const Drawer = ({ isOpen, friendRequests, handleFriendRequests }: DrawerProps) => {
   const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
 
   const handleProfileEditButtonClick = () => {
@@ -45,7 +44,7 @@ const Drawer = ({ isOpen, friendRequests, handleFriendRequests, handleLogoutButt
         <ReceivedFriendRequestSection friendRequests={friendRequests} handleFriendRequests={handleFriendRequests} />
         <S.HorizontalRule />
         <NotificationSection />
-        <S.LogoutButton onClick={handleLogoutButtonClick} href="#">
+        <S.LogoutButton onClick={() => sendLogoutRequest()} href="#">
           로그아웃
         </S.LogoutButton>
       </S.Drawer>

--- a/client/src/components/FriendsBar/FriendSearchForm.tsx
+++ b/client/src/components/FriendsBar/FriendSearchForm.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Friend } from 'GlobalType';
 import styled from 'styled-components';
 import { HOST } from '../../constants';
 import FriendSearchInput from './FriendSearchInput';

--- a/client/src/components/FriendsBar/FriendSearchInput.tsx
+++ b/client/src/components/FriendsBar/FriendSearchInput.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 import axios from 'axios';
 import { HOST } from '../../constants';
 import styled from 'styled-components';
 import useInput from '../../hooks/useInput';
-import { RiCloseLine } from 'react-icons/ri';
-import { Friend } from 'GlobalType';
 
 axios.defaults.withCredentials = true; // withCredentials 전역 설정
 

--- a/client/src/components/FriendsBar/FriendsBar.tsx
+++ b/client/src/components/FriendsBar/FriendsBar.tsx
@@ -1,15 +1,13 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { useRecoilState } from 'recoil';
-import { Friend } from 'GlobalType';
+import React, { useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { sendUnfriendRequest } from './FriendsBarAPI';
 import * as S from './FriendsBar.style';
-import { visitState, friendState } from '../common/atoms';
+import { visitState, friendState, myInfo } from '../common/atoms';
 import Modal from '../common/Modal';
 import { MODAL_CENTER_TOP, MODAL_CENTER_LEFT, MODAL_CENTER_TRANSFORM, HOST } from '../../constants/index';
 import { ProfileImage } from '../Drawer/Drawer.style';
 
 interface FriendsBarProps {
-  myProfile: Friend | null;
   handlePlusButtonClick: React.MouseEventHandler;
 }
 
@@ -29,12 +27,13 @@ interface FriendProfileModalProps {
   profileImg: string;
 }
 
-const FriendsBar = ({ myProfile, handlePlusButtonClick }: FriendsBarProps) => {
+const FriendsBar = ({ handlePlusButtonClick }: FriendsBarProps) => {
   const plusIcon = '/plus.svg';
   const [currentFriendOnMenu, setCurrentFriendOnMenu] = useState<Friend | null>(null);
   const [isDoubleCheckModalOpen, setIsDoubleCheckMdoalOpen] = useState(false);
   const [isFriendProfileOpen, setIsFriendProfileOpen] = useState(false);
   const [friendsList, setFriendsList] = useRecoilState(friendState);
+  const myProfile = useRecoilValue(myInfo);
 
   const closeDoubleCheckModal = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -78,7 +77,7 @@ const FriendsBar = ({ myProfile, handlePlusButtonClick }: FriendsBarProps) => {
             onContextMenu={(e) => handleRightClick(e)}
             nowVisiting={currentVisit.userId === userId}
           ></S.ProfileBox>
-          {currentFriendOnMenu?.userId === userId && userId !== myProfile?.userId && <FriendMenuModal setIsDoubleCheckMdoalOpen={setIsDoubleCheckMdoalOpen} setIsFriendProfileOpen={setIsFriendProfileOpen}></FriendMenuModal>}
+          {currentFriendOnMenu?.userId === userId && userId !== myProfile!.userId && <FriendMenuModal setIsDoubleCheckMdoalOpen={setIsDoubleCheckMdoalOpen} setIsFriendProfileOpen={setIsFriendProfileOpen}></FriendMenuModal>}
         </div>
       </>
     );

--- a/client/src/components/FriendsBar/FriendsBarAPI.ts
+++ b/client/src/components/FriendsBar/FriendsBarAPI.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { Axios, AxiosResponse } from 'axios';
 import { HOST, API_VERSION } from '../../constants';
 import { authorizedHttpRequest } from '../common/utils';
 
@@ -22,6 +22,10 @@ const fetchLogoutRequest = async () => {
   await axios.get(`${HOST}/api/v1/auth/logout`);
   alert('로그아웃되었습니다');
   window.location.href = '/';
+};
+
+const sendFriendRequest = async (selectedFriend: number) => {
+  await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
 };
 
 //API
@@ -55,7 +59,7 @@ export const getMyProfile = async () => {
 
 export const postFriendRequest = async (selectedFriend: number) => {
   try {
-    const response = await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
+    const response = await authorizedHttpRequest(() => sendFriendRequest(selectedFriend));
     if (response.status === 201) alert('친구요청을 완료했습니다');
   } catch (error: any) {
     alert(error.response.data.msg);

--- a/client/src/components/FriendsBar/FriendsBarAPI.ts
+++ b/client/src/components/FriendsBar/FriendsBarAPI.ts
@@ -1,12 +1,79 @@
 import axios from 'axios';
 import { HOST, API_VERSION } from '../../constants';
-export const sendUnfriendRequest = async(friendIdx:number):Promise<boolean> =>{
-    try{
-        await axios.delete(`${HOST}/${API_VERSION}/friend/${friendIdx}`)
-        alert('친구를 삭제했습니다')
-        return true;
-    }catch (err){
-        console.log(err)
-        return false;
-    }
-}
+import { authorizedHttpRequest } from '../common/utils';
+
+//query
+const fetchFriendList = async () => {
+  const response = await axios.get(`${HOST}/api/v1/friend`);
+  return response.data;
+};
+
+const fetchMyProfile = async () => {
+  const response = await axios.get(`${HOST}/api/v1/user/me`);
+  return response.data;
+};
+
+const fetchFriendRequests = async (): Promise<Friend[]> => {
+  const response = await axios.get(`${HOST}/api/v1/friend/request`);
+  return response.data;
+};
+
+const fetchLogoutRequest = async () => {
+  await axios.get(`${HOST}/api/v1/auth/logout`);
+  alert('로그아웃되었습니다');
+  window.location.href = '/';
+};
+
+//API
+
+export const sendUnfriendRequest = async (friendIdx: number): Promise<boolean> => {
+  try {
+    await axios.delete(`${HOST}/${API_VERSION}/friend/${friendIdx}`);
+    alert('친구를 삭제했습니다');
+    return true;
+  } catch (err) {
+    console.log(err);
+    return false;
+  }
+};
+
+export const getFriendsList = async (): Promise<Friend[]> => {
+  try {
+    return authorizedHttpRequest(() => fetchFriendList());
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const getMyProfile = async () => {
+  try {
+    return authorizedHttpRequest(() => fetchMyProfile());
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const postFriendRequest = async (selectedFriend: number) => {
+  try {
+    const response = await axios.put(`${HOST}/api/v1/friend/request/${selectedFriend}`);
+    if (response.status === 201) alert('친구요청을 완료했습니다');
+  } catch (error: any) {
+    alert(error.response.data.msg);
+  }
+};
+
+export const getFriendRequests = async (): Promise<Friend[]> => {
+  try {
+    return authorizedHttpRequest(() => fetchFriendRequests());
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const sendLogoutRequest = async () => {
+  try {
+    authorizedHttpRequest(() => fetchLogoutRequest());
+  } catch (error) {
+    throw error;
+  }
+};

--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -4,7 +4,7 @@ import { myInfo, visitState } from '../common/atoms';
 import useCurrentDate from '../../hooks/useCurrentDate';
 import globalSocket from '../common/Socket';
 import { DEFAULT_OBJECT_VALUE } from '../../constants';
-import { Shape, FabricText, FabricLine, ShapeType, FabricObject, ObjectData, Friend } from 'GlobalType';
+import { Shape, FabricText, FabricLine, ShapeType, FabricObject, ObjectData } from 'GlobalType';
 import { fabric } from 'fabric';
 import { v4 } from 'uuid';
 import styled from 'styled-components';

--- a/client/src/components/MainContainer/Diary.tsx
+++ b/client/src/components/MainContainer/Diary.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { visitState, menuState, dateState } from '../common/atoms';
-import { Friend } from 'GlobalType';
 import Canvas from './Canvas';
 import * as S from './Diary.style';
 

--- a/client/src/components/common/Socket.ts
+++ b/client/src/components/common/Socket.ts
@@ -1,4 +1,4 @@
-import { FabricText, Shape, FabricLine, ObjectData, Friend } from 'GlobalType';
+import { FabricText, Shape, FabricLine, ObjectData } from 'GlobalType';
 import { io, Socket } from 'socket.io-client';
 import { HOST } from '../../constants/index';
 

--- a/client/src/components/common/atoms.ts
+++ b/client/src/components/common/atoms.ts
@@ -1,5 +1,4 @@
 import { atom, selector } from 'recoil';
-import { Friend } from 'GlobalType';
 
 export const dateState = atom({
   key: 'currentDate',

--- a/client/src/types/type.d.ts
+++ b/client/src/types/type.d.ts
@@ -1,11 +1,4 @@
 declare module 'GlobalType' {
-  interface Friend {
-    idx: number;
-    userId: string;
-    username: string;
-    profileImg: string;
-  }
-
   interface LabelData {
     labelIdx: number;
     title: string;
@@ -136,4 +129,10 @@ interface ModalProps {
 
 interface Window {
   kakao: any;
+}
+interface Friend {
+  idx: number;
+  userId: string;
+  username: string;
+  profileImg: string;
 }


### PR DESCRIPTION
## 요약
FriendBar 컴포넌트 및 Friend 관련 API 정리(authorization check포함)
## 작동 화면
없다면 생략

## 작업 내용
1. Friend 관련 API 호출 파트를 분리하여 하나의 파일로 관리
2.  API호출마다 response를 확인하여 로그인이 풀렸을때의 status(403 or 401)를 받는다면 새로고침하여 로그인페이지로 이동하도록 수정

## 테스트 방법
1.

## 관련 Task
-[117]

## 비고
