### PR TITLE
[BE] [112] 라벨 조회 API 수정

### DIFF
--- a/server/src/api/label.ts
+++ b/server/src/api/label.ts
@@ -41,9 +41,10 @@ class ValidationError extends Error {}
 router.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const labels = await executeSql('select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) as count from label left join task_label on label.idx = task_label.label_idx where label.user_idx = ? group by label.idx', [
-      userIdx,
-    ]);
+    const labels = await executeSql(
+      'select label.idx, label.title, label.color, label.unit, count(task_label.label_idx) + count(goal.idx) as count from label left join task_label on label.idx = task_label.label_idx left join goal on label.idx = goal.label_idx where label.user_idx = ? group by label.idx',
+      [userIdx]
+    );
     res.json(labels);
   } catch {
     res.sendStatus(500);


### PR DESCRIPTION
## 요약
라벨 정보 조회 시 `count` 값을 계산할 때 `task`에 추가된 라벨을 대상으로만 계산하여 `goal`에만 사용된 라벨의 경우 `count = 0`으로 계산되는 버그가 있었습니다.
해당 버그로 인해 `task`에 추가되지 않고 `goal`에만 추가된 라벨의 경우 UI 상에 삭제 버튼이 나타나지만 삭제 버튼을 눌러도 DB 에러로 인해 아무런 동작이 일어나지 않는 현상이 발생하였습니다.
`goal`에 사용된 횟수와 `task`에 사용된 횟수를 합쳐서 `count` 값으로 반환하도록 수정하여 해결하였습니다.

## 작동 화면
1. `/label`를 통해 `goal`에 사용된 횟수가 반영된 `count` 값을 포함한 라벨 목록이 반환되는 것을 확인

[a2d6ca91-f8db-4dc3-b610-5a862e03ffaf.webm](https://user-images.githubusercontent.com/92143119/207665371-32f0c1a0-8606-440e-a27e-ae4e57c871fc.webm)

## 작업 내용
1. 라벨 조회 API `count` 정보에 `goal`에 사용된 횟수도 반영하도록 수정

## 테스트 방법
1. 로그인을 완료합니다.
2. `/label`를 통해 라벨 목록을 조회합니다.

## 관련 Task
- [112]