### PR TITLE
[110] [FE/BE] 알림

### DIFF
--- a/client/src/components/Drawer/Drawer.style.ts
+++ b/client/src/components/Drawer/Drawer.style.ts
@@ -275,3 +275,7 @@ export const LogoutButton = styled.a`
   margin-top: auto;
   padding-bottom: 1rem;
 `;
+
+export const AlarmTargetTitle = styled.span`
+  font-weight: bold;
+`;

--- a/client/src/components/Drawer/Drawer.style.ts
+++ b/client/src/components/Drawer/Drawer.style.ts
@@ -260,6 +260,9 @@ export const NotificationSection = styled.div`
 export const Notification = styled.div`
   margin: 0.3rem 0;
   margin-left: 0.5rem;
+  font-size: 0.9rem;
+  word-break: keep-all;
+  word-wrap: break-word;
   &::before {
     content: '-';
     margin-right: 0.5rem;

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -186,12 +186,54 @@ const NotificationSection = () => {
     <S.NotificationSection>
       <S.SectionHeader>알림</S.SectionHeader>
       <div>
-        {feed.map(({ idx, content }) => (
-          <S.Notification key={idx}>{content}</S.Notification>
+        {feed.map(({ idx, ...props }: any) => (
+          <S.Notification>
+            <AlarmContent key={idx} {...props} />
+          </S.Notification>
         ))}
       </div>
     </S.NotificationSection>
   );
+};
+
+const AlarmTypes = {
+  TASK_EMOTICON: 'task_emoticon',
+  DIARY_EDIT: 'diary_edit',
+};
+
+type AlarmTypes = typeof AlarmTypes[keyof typeof AlarmTypes];
+
+interface Alarm {
+  type: AlarmTypes;
+  publisherIdx: number;
+  title: string;
+  idx: number;
+}
+
+const AlarmContent = ({ type, publisherIdx, title }: Alarm) => {
+  switch (type) {
+    case AlarmTypes.TASK_EMOTICON: {
+      return (
+        <>
+          {publisherIdx} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 태스크에 이모티콘을 남겼어요.
+        </>
+      );
+    }
+    case AlarmTypes.DIARY_EDIT: {
+      return (
+        <>
+          {publisherIdx} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 다이어리에 참여했어요.
+        </>
+      );
+    }
+    default: {
+      return (
+        <>
+          {publisherIdx} {title} {type}
+        </>
+      );
+    }
+  }
 };
 
 export default Drawer;

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -205,31 +205,31 @@ type AlarmTypes = typeof AlarmTypes[keyof typeof AlarmTypes];
 
 interface Alarm {
   type: AlarmTypes;
-  publisherIdx: number;
+  publisherId: number;
   title: string;
   idx: number;
 }
 
-const AlarmContent = ({ type, publisherIdx, title }: Alarm) => {
+const AlarmContent = ({ type, publisherId, title }: Alarm) => {
   switch (type) {
     case AlarmTypes.TASK_EMOTICON: {
       return (
         <>
-          {publisherIdx} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 태스크에 이모티콘을 남겼어요.
+          {publisherId} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 태스크에 이모티콘을 남겼어요.
         </>
       );
     }
     case AlarmTypes.DIARY_EDIT: {
       return (
         <>
-          {publisherIdx} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 다이어리에 참여했어요.
+          {publisherId} 님이 <S.AlarmTargetTitle>{title}</S.AlarmTargetTitle> 다이어리에 참여했어요.
         </>
       );
     }
     default: {
       return (
         <>
-          {publisherIdx} {title} {type}
+          {publisherId} {title} {type}
         </>
       );
     }

--- a/server/src/api/alarm.ts
+++ b/server/src/api/alarm.ts
@@ -8,9 +8,10 @@ export const alarmRouter = Router();
 alarmRouter.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const alarms = await executeSql('select type, publisher_idx as publisherIdx, content as title from alarm where receiver_idx = ? and status = false order by idx desc', [userIdx]);
+    const alarms = await executeSql('select type, user.user_id as publisherId, content as title from alarm inner join user on user.idx = alarm.publisher_idx where receiver_idx = ? and status = false order by alarm.idx desc', [userIdx]);
     res.status(200).json(alarms);
   } catch (error) {
+    console.log(error);
     res.sendStatus(500);
   }
 });

--- a/server/src/api/alarm.ts
+++ b/server/src/api/alarm.ts
@@ -8,7 +8,7 @@ export const alarmRouter = Router();
 alarmRouter.get('/', authenticateToken, async (req: AuthorizedRequest, res) => {
   const { userIdx } = req.user;
   try {
-    const alarms = await executeSql('select * from alarm where receiver_idx = ? and status = false', [userIdx]);
+    const alarms = await executeSql('select type, publisher_idx as publisherIdx, content as title from alarm where receiver_idx = ? and status = false order by idx desc', [userIdx]);
     res.status(200).json(alarms);
   } catch (error) {
     res.sendStatus(500);

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -92,7 +92,7 @@ router.post('/login', async (req, res) => {
   [user] = (await executeSql('select * from user where user_id = ? and password = ?', [userId, encrypted])) as RowDataPacket[];
   if (!user) return res.status(401).json({ msg: '아이디 또는 비밀번호가 틀렸어요.' });
 
-  const token = generateAccessToken({ userIdx: user.idx });
+  const token = generateAccessToken({ userIdx: user.idx, userId: user.user_id, username: user.username, profileImg: user.profile_img });
   res.cookie('token', token, {
     httpOnly: true,
   });
@@ -117,7 +117,7 @@ router.get('/login/:oauth_type/callback', async (req, res) => {
   const oauthEmail = await httpGetOAuthUserIdentifier(oauthType, accessToken); // 변수 이름. (카카오에서는 이메일 얻기 위해 검수 필요)
 
   const [user] = (await executeSql('select * from user where oauth_type = ? and oauth_email = ?', [oauthType, oauthEmail])) as RowDataPacket[];
-  const token = generateAccessToken(user ? { userIdx: user.idx } : { oauthType, oauthEmail });
+  const token = generateAccessToken(user ? { userIdx: user.idx, userId: user.user_id, username: user.username, profileImg: user.profile_img } : { oauthType, oauthEmail });
 
   res.cookie('token', token, {
     httpOnly: true,

--- a/server/src/api/emoticon.ts
+++ b/server/src/api/emoticon.ts
@@ -49,9 +49,7 @@ router.put('/task/:task_idx', authenticateToken, async (req: PutEmoticonRequest,
 
     await executeSql('insert into task_social_action (task_idx, emoticon_idx, author_idx) values (?, ?, ?);', [taskIdx, emoticon, userIdx]);
 
-    // todo: 한방 쿼리..?
     const { receiverIdx, title } = (await executeSql('select user_idx as receiverIdx, title from task where idx = ?', [taskIdx]))[0];
-    const { receiverId } = (await executeSql('select user_id as receiverId from user where idx = ?', [receiverIdx]))[0];
 
     await executeSql(`insert into alarm (publisher_idx, receiver_idx, type, content, redirect, status) values (?, ?, '${AlarmType.TASK_EMOTICON}', ?, '${redirectURI}', false)`, [userIdx, receiverIdx, title]);
     res.sendStatus(201);

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -2,6 +2,7 @@ import { Request } from 'express';
 
 declare interface AuthorizedRequest extends Request {
   user?: {
+    userId: string;
     userIdx?: number;
     oauthType?: string;
     oauthEmail?: string;


### PR DESCRIPTION
## 요약
- 이제 JWT가 유저 프로필 정보를 포함합니다.
- 서버: 이모티콘을 남기거나 다이어리 입장 시 알림을 생성하고 DB에 저장합니다.
- 클라이언트: 받아온 알림 목록을 알림 타입에 따라 알맞게 렌더링합니다.

## 작동 화면
<img width="261" alt="스크린샷 2022-12-15 오후 4 00 19" src="https://user-images.githubusercontent.com/55306894/207794175-da11570d-af01-471c-b891-bc04482e94ee.png">

## 비고
- alarm 테이블의 구조를 변경하면 좋을 것 같습니다
  - `content` → `title`: 태스크 제목이나, 다이어리 날짜 (위 사진에서 bold 처리된 부분)
  - `receiver_idx` → `receiver_id`
  - `publisher_idx` → `publisher_id`
- 현재는 자신의 다이어리에 입장해도 알림이 생성됩니다.