### PR TITLE
[FE] [120] top과 left가 아닌 transform으로 drag 요소 위치 변경

### DIFF
--- a/client/src/components/MainContainer/Log.tsx
+++ b/client/src/components/MainContainer/Log.tsx
@@ -20,12 +20,13 @@ interface Tag {
 
 const Log = () => {
   const [selectedTask, setSelectedTask] = useState<{ idx: number; tagIdx: number } | null>(null);
-  const [mousePosition, setMousePosition] = useState<number[]>([0, 0]);
+  const selectedTaskRef = useRef<HTMLDivElement | null>(null);
   const [taskList, setTaskList] = useState<Task[]>([]);
   const [activeTask, setActiveTask] = useState<number | null>(null);
   const [timeMarkerData, setTimeMarkerData] = useState<number[]>([0, 0]);
   const [completionCheckBoxStatus, setCompletionCheckBoxStatus] = useState<CompletionCheckBoxStatus>({ complete: true, incomplete: true });
-  const selectedTaskRef = useRef<HTMLDivElement | null>(null);
+  const dummyTaskRef = useRef<HTMLDivElement | null>(null);
+  const mouseStartRef = useRef<number[]>([0, 0]);
   const mouseOffsetRef = useRef<number[]>([0, 0]);
   const taskContainerRef = useRef<HTMLDivElement | null>(null);
   const { currentDate } = useCurrentDate();
@@ -77,8 +78,8 @@ const Log = () => {
     if (!(e.target instanceof HTMLDivElement)) return;
     const target = e.target;
     if (!target.dataset.idx) return;
+    mouseStartRef.current = [e.pageX, e.pageY];
     mouseOffsetRef.current = [e.nativeEvent.offsetX, e.nativeEvent.offsetY];
-    setMousePosition([e.pageX - mouseOffsetRef.current[0], e.pageY - mouseOffsetRef.current[1]]);
     const timeout = setTimeout(() => {
       if (target.dataset.idx) {
         setSelectedTask({ idx: Number(target.dataset.idx), tagIdx: Number(target.dataset.tag) });
@@ -131,7 +132,8 @@ const Log = () => {
 
     if (!(e.target instanceof HTMLDivElement)) return;
     const target = e.target;
-    setMousePosition([e.pageX - mouseOffsetRef.current[0], e.pageY - mouseOffsetRef.current[1]]);
+    if (!dummyTaskRef.current) return;
+    dummyTaskRef.current.style.transform = `translate(${e.pageX - mouseStartRef.current[0]}px,${e.pageY - mouseStartRef.current[1]}px)`;
     if (target.dataset.direction && taskContainerRef.current) {
       if (target.dataset.direction === 'left') {
         taskContainerRef.current.scrollBy(-10, 0);
@@ -187,7 +189,7 @@ const Log = () => {
   return (
     <>
       {selectedTask !== null && (
-        <S.SelectedItem x={mousePosition[0]} y={mousePosition[1]}>
+        <S.SelectedItem ref={dummyTaskRef} x={mouseStartRef.current[0] - mouseOffsetRef.current[0]} y={mouseStartRef.current[1] - mouseOffsetRef.current[1]}>
           <span>{TaskMap.get(selectedTask.idx).startedAt}</span> {TaskMap.get(selectedTask.idx).title}
         </S.SelectedItem>
       )}


### PR DESCRIPTION
## 요약
top과 left 변경으로 이동하던 drag element를 transform 변경으로 변경하였습니다
## 작동 화면
![GIF 2022-12-15 오후 9-28-35](https://user-images.githubusercontent.com/109147404/207860836-d6cb8bc1-6fb5-4191-80e9-c117d78bf038.gif)

## 작업 내용
1. mousePosition 상태 변화로 재렌더링 하던 기존 로직을 변경
2. 처음 클릭할때의 마우스 위치만 저장하고 나머지는 mousemove 이벤트에 따라 transform 속성 변경

## 테스트 방법
1.개발자도구에서 성능모니터를 이용하여 기존 로직(지금은 배포서버)와 로컬서버 성능차이를 확인합니다.

## 관련 Task
- [120]

## 비고
