### PR TITLE
[FE] [124] 다이어리 도형 버튼과 실제 만들어지는 도형이 일치하지 않던 버그 수정

### DIFF
--- a/client/src/components/MainContainer/Canvas.tsx
+++ b/client/src/components/MainContainer/Canvas.tsx
@@ -357,8 +357,8 @@ const Canvas = ({ setAuthorList, setOnlineList }: CanvasProps) => {
           <MarkerIcon onClick={() => enterDrawingMode(10)} />
           <PaintIcon onClick={() => enterDrawingMode(18)} />
           <RectIcon onClick={() => createNewShape('rect')} />
-          <CircleIcon onClick={() => createNewShape('triangle')} />
-          <TriangleIcon onClick={() => createNewShape('circle')} />
+          <CircleIcon onClick={() => createNewShape('circle')} />
+          <TriangleIcon onClick={() => createNewShape('triangle')} />
           <TextIcon onClick={() => createNewText()} />
           <ColorPicker type="color" ref={colorRef} onChange={changeBrushColor} />
         </Palette>


### PR DESCRIPTION
## 요약
다이어리 도형 버튼과 실제 만들어지는 도형이 일치하지 않던 버그를 수정하였습니다.

## 작동 화면
[221363d6-0ccb-4ea3-b900-9ea62b6a41be.webm](https://user-images.githubusercontent.com/92143119/208279171-a98ad195-f4ba-4bf7-abbc-dc26575d3b1d.webm)

## 작업 내용
1. 다이어리 도형 버튼과 실제 만들어지는 도형이 일치하지 않던 버그 수정

## 관련 Task
- [124]