### PR TITLE
[BE] [127] OAuth 회원가입 시 서버가 중단되는 버그 수정

### DIFF
--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -14,6 +14,7 @@ export const authenticateToken = (req: AuthorizedRequest, res: Response, next: N
 
   jwt.verify(token, TOKEN_SECRET, (err, user) => {
     if (err) return res.sendStatus(403);
+    if (!user.userIdx) return res.sendStatus(401);
 
     req.user = user;
     next();


### PR DESCRIPTION
## 요약
OAuth를 이용하여 회원가입 시 서버가 중단되는 버그가 있었습니다.
JWT 검증 시 유효하지 않은 `user` 정보에 대한 예외 처리가 되어 있지 않아 발생한 문제였습니다.
`user`에 인덱스 정보가 포함되어 있지 않다면 `401` 코드를 반환하도록 수정하여 해결하였습니다.

## 작업 내용
1. JWT 검증 시 `user`에 인덱스 정보가 포함되어 있지 않을 때의 예외 처리 추가

## 관련 Task
- [127]